### PR TITLE
Improve timeline readability across zoom levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,913 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Timeline Interattiva • Storia d'Italia 1848-1948</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        :root {
+            --timeline-zoom: 1;
+            --period-label-scale: 1;
+            --event-text-scale: 1;
+            --event-card-scale: 1;
+            --tick-text-scale: 1;
+        }
+
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: radial-gradient(circle at top, rgba(103, 58, 183, 0.25), transparent 45%),
+                        radial-gradient(circle at bottom, rgba(3, 169, 244, 0.25), transparent 40%),
+                        linear-gradient(135deg, #080b24 0%, #14183a 35%, #10152b 100%);
+            min-height: 100vh;
+            color: #f5f7ff;
+            overflow: hidden;
+        }
+
+        .bg-particles {
+            position: fixed;
+            inset: 0;
+            pointer-events: none;
+            z-index: 0;
+            opacity: 0.4;
+        }
+
+        .particle {
+            position: absolute;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: radial-gradient(circle, rgba(255,255,255,0.9) 0%, rgba(255,255,255,0) 70%);
+            animation: float 16s infinite ease-in-out;
+            filter: blur(0.3px);
+        }
+
+        @keyframes float {
+            0%, 100% { transform: translate3d(0, 0, 0) scale(1); opacity: 0.35; }
+            33% { transform: translate3d(30px, -60px, 0) scale(1.15); opacity: 0.6; }
+            66% { transform: translate3d(-40px, 20px, 0) scale(0.9); opacity: 0.2; }
+        }
+
+        header {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            padding: 22px 32px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 24px;
+            z-index: 3;
+            backdrop-filter: blur(18px);
+            background: rgba(8, 11, 36, 0.75);
+            border-bottom: 1px solid rgba(255,255,255,0.08);
+        }
+
+        h1 {
+            font-size: clamp(1.4rem, 1.2rem + 1vw, 2rem);
+            font-weight: 800;
+            letter-spacing: 0.04em;
+            background: linear-gradient(120deg, #8d9eff, #f48fb1);
+            -webkit-background-clip: text;
+            color: transparent;
+            text-transform: uppercase;
+        }
+
+        .controls {
+            display: flex;
+            gap: 16px;
+            align-items: center;
+        }
+
+        .zoom-controls {
+            display: flex;
+            align-items: center;
+            border-radius: 999px;
+            background: rgba(255,255,255,0.08);
+            border: 1px solid rgba(255,255,255,0.08);
+            overflow: hidden;
+            box-shadow: 0 12px 30px rgba(10, 20, 60, 0.25);
+        }
+
+        .zoom-btn {
+            background: none;
+            border: none;
+            color: #f5f7ff;
+            padding: 10px 18px;
+            font-size: 1.4rem;
+            cursor: pointer;
+            transition: background 0.2s ease, transform 0.2s ease;
+        }
+
+        .zoom-btn:hover {
+            background: rgba(255,255,255,0.12);
+            transform: translateY(-1px);
+        }
+
+        .zoom-level {
+            padding: 10px 18px;
+            font-size: 0.9rem;
+            color: rgba(255,255,255,0.85);
+            font-weight: 700;
+            border-left: 1px solid rgba(255,255,255,0.06);
+            border-right: 1px solid rgba(255,255,255,0.06);
+        }
+
+        .legend {
+            display: flex;
+            gap: 16px;
+            align-items: center;
+            background: rgba(255,255,255,0.08);
+            padding: 10px 18px;
+            border-radius: 999px;
+            font-size: 0.9rem;
+            border: 1px solid rgba(255,255,255,0.08);
+        }
+
+        .legend span {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .legend i {
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+        }
+
+        .timeline-shell {
+            position: absolute;
+            top: 110px;
+            left: 0;
+            right: 0;
+            bottom: 120px;
+            overflow: hidden;
+            cursor: grab;
+            z-index: 1;
+        }
+
+        .timeline-shell.dragging {
+            cursor: grabbing;
+        }
+
+        .timeline-wrapper {
+            position: absolute;
+            inset: 0;
+            transform: translateX(0px);
+            will-change: transform;
+        }
+
+        .timeline-inner {
+            position: absolute;
+            top: 50%;
+            left: 0;
+            transform-origin: left center;
+            transform: scale(1);
+            will-change: transform;
+        }
+
+        .timeline-main {
+            position: absolute;
+            top: 50%;
+            left: 0;
+            height: 4px;
+            transform: translateY(-50%);
+            border-radius: 999px;
+            background: linear-gradient(90deg, rgba(141,158,255,0.9), rgba(244,143,177,0.9));
+            box-shadow: 0 0 24px rgba(120,140,255,0.5);
+        }
+
+        .timeline-tick {
+            position: absolute;
+            bottom: -22px;
+            width: 2px;
+            background: rgba(255,255,255,0.3);
+            height: 14px;
+        }
+
+        .timeline-tick.major {
+            height: 26px;
+            background: rgba(255,255,255,0.6);
+        }
+
+        .timeline-tick-label {
+            position: absolute;
+            bottom: -46px;
+            left: 50%;
+            transform: translateX(-50%);
+            font-size: calc(0.75rem * var(--tick-text-scale));
+            color: rgba(255,255,255,0.75);
+            white-space: nowrap;
+        }
+
+        .period {
+            position: absolute;
+            transform: translateY(-50%);
+            border-radius: 14px;
+            padding: 8px 20px;
+            color: #fff;
+            font-weight: 700;
+            font-size: calc(1.05rem * var(--period-label-scale));
+            letter-spacing: 0.02em;
+            text-shadow: 0 6px 18px rgba(0,0,0,0.55), 0 0 12px rgba(5,7,19,0.75);
+            backdrop-filter: blur(10px);
+            box-shadow: 0 10px 30px rgba(0,0,0,0.35);
+            transition: transform 0.2s ease, opacity 0.2s ease;
+            opacity: 0.9;
+        }
+
+        .period:hover {
+            opacity: 1;
+            transform: translateY(-50%) scale(1.04);
+            z-index: 4;
+        }
+
+        .event {
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%, calc(-50% + var(--event-offset, 0px)));
+            cursor: pointer;
+            transition: transform 0.2s ease;
+            z-index: 2;
+        }
+
+        .event-marker {
+            width: 16px;
+            height: 16px;
+            border-radius: 50%;
+            background: linear-gradient(135deg, #ffffff, #c5cae9);
+            box-shadow: 0 0 16px rgba(255,255,255,0.75);
+            position: relative;
+        }
+
+        .event-marker::before {
+            content: '';
+            position: absolute;
+            inset: -10px;
+            border-radius: 50%;
+            border: 1px solid rgba(255,255,255,0.4);
+            opacity: 0;
+            transform: scale(0.6);
+            transition: transform 0.3s ease, opacity 0.3s ease;
+        }
+
+        .event:hover {
+            z-index: 8;
+        }
+
+        .event:hover .event-marker::before {
+            opacity: 1;
+            transform: scale(1);
+        }
+
+        .event-card {
+            position: absolute;
+            left: 50%;
+            bottom: calc(100% + 18px);
+            transform: translate(-50%, calc(12px * var(--event-card-scale))) scale(0.95);
+            transform-origin: bottom;
+            min-width: calc(260px * var(--event-card-scale));
+            max-width: calc(320px * var(--event-card-scale));
+            background: rgba(8,11,36,0.95);
+            border-radius: 16px;
+            padding: calc(18px * var(--event-card-scale)) calc(20px * var(--event-card-scale));
+            border: 1px solid rgba(255,255,255,0.08);
+            box-shadow: 0 24px 50px rgba(0,0,0,0.45);
+            opacity: 0;
+            pointer-events: none;
+            transition: transform 0.25s ease, opacity 0.25s ease;
+        }
+
+        .event:hover .event-card {
+            opacity: 1;
+            transform: translate(-50%, 0) scale(1);
+        }
+
+        .event-date {
+            font-size: calc(0.75rem * var(--event-text-scale));
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            color: #8d9eff;
+            margin-bottom: 6px;
+        }
+
+        .event-title {
+            font-size: calc(1.05rem * var(--event-text-scale));
+            font-weight: 700;
+            margin-bottom: 8px;
+            color: #fff;
+        }
+
+        .event-description {
+            font-size: calc(0.92rem * var(--event-text-scale));
+            line-height: 1.55;
+            color: rgba(235,240,255,0.85);
+        }
+
+        .event-image {
+            width: 100%;
+            height: calc(140px * var(--event-card-scale));
+            object-fit: cover;
+            border-radius: 12px;
+            margin-top: 14px;
+            border: 1px solid rgba(255,255,255,0.06);
+        }
+
+        .timeline-inner.zoom-low .event[data-level="2"],
+        .timeline-inner.zoom-low .event[data-level="3"] {
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        .timeline-inner.zoom-medium .event[data-level="3"] {
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        .timeline-inner .event {
+            opacity: 1;
+        }
+
+        .event[data-side="bottom"] .event-card {
+            bottom: auto;
+            top: calc(100% + 18px);
+            transform-origin: top;
+        }
+
+        .event[data-side="bottom"] .event-card {
+            transform: translate(-50%, calc(-12px * var(--event-card-scale))) scale(0.95);
+        }
+
+        .event[data-side="bottom"]:hover .event-card {
+            transform: translate(-50%, 0) scale(1);
+        }
+
+        .minimap {
+            position: fixed;
+            bottom: 26px;
+            left: 50%;
+            transform: translateX(-50%);
+            width: min(90vw, 960px);
+            height: 84px;
+            border-radius: 32px;
+            background: rgba(8,11,36,0.82);
+            border: 1px solid rgba(255,255,255,0.08);
+            padding: 16px 24px;
+            display: flex;
+            align-items: center;
+            z-index: 3;
+            box-shadow: 0 24px 60px rgba(0,0,0,0.45);
+        }
+
+        .minimap-track {
+            position: relative;
+            flex: 1;
+            height: 100%;
+            border-radius: 18px;
+            background: rgba(255,255,255,0.08);
+            overflow: hidden;
+        }
+
+        .minimap-event {
+            position: absolute;
+            top: 50%;
+            width: 4px;
+            height: 4px;
+            border-radius: 50%;
+            background: rgba(255,255,255,0.7);
+            transform: translate(-50%, -50%);
+        }
+
+        .minimap-period {
+            position: absolute;
+            top: 50%;
+            height: 50%;
+            border-radius: 12px;
+            transform: translateY(-50%);
+            opacity: 0.55;
+        }
+
+        .minimap-viewport {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            border-radius: 16px;
+            border: 2px solid rgba(141,158,255,0.85);
+            background: rgba(141,158,255,0.2);
+            cursor: grab;
+            transition: none;
+        }
+
+        .year-indicator {
+            position: fixed;
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.2s ease;
+            z-index: 2;
+        }
+
+        .year-indicator.show {
+            opacity: 1;
+        }
+
+        .year-badge {
+            padding: 12px 28px;
+            border-radius: 999px;
+            background: rgba(141,158,255,0.9);
+            color: #050713;
+            font-size: 1.4rem;
+            font-weight: 700;
+            box-shadow: 0 20px 50px rgba(141,158,255,0.4);
+        }
+
+        @media (max-width: 860px) {
+            header {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .controls {
+                width: 100%;
+                flex-wrap: wrap;
+                justify-content: space-between;
+            }
+
+            .legend {
+                width: 100%;
+                justify-content: center;
+            }
+
+            .minimap {
+                width: 92vw;
+                height: 70px;
+                padding: 12px 16px;
+            }
+        }
+
+        @media (max-width: 520px) {
+            header {
+                padding: 18px 18px;
+            }
+
+            .timeline-shell {
+                top: 120px;
+                bottom: 110px;
+            }
+
+            .event-card {
+                min-width: 220px;
+                max-width: 240px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="bg-particles" aria-hidden="true"></div>
+
+    <header>
+        <h1>Storia d'Italia 1848 – 1948</h1>
+        <div class="controls">
+            <div class="zoom-controls" aria-label="Controlli zoom">
+                <button class="zoom-btn" data-action="out" aria-label="Riduci zoom">−</button>
+                <div class="zoom-level" aria-live="polite">100%</div>
+                <button class="zoom-btn" data-action="in" aria-label="Aumenta zoom">+</button>
+            </div>
+            <div class="legend">
+                <span><i style="background: linear-gradient(135deg,#2196f3,#21cbf3);"></i> Periodi storici</span>
+                <span><i style="background: linear-gradient(135deg,#ffffff,#c5cae9);"></i> Eventi principali</span>
+            </div>
+        </div>
+    </header>
+
+    <div class="timeline-shell">
+        <div class="timeline-wrapper">
+            <div class="timeline-inner">
+                <div class="timeline-main"></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="year-indicator" aria-hidden="true">
+        <div class="year-badge">1861</div>
+    </div>
+
+    <div class="minimap" aria-hidden="false">
+        <div class="minimap-track">
+            <div class="minimap-viewport"></div>
+        </div>
+    </div>
+
+    <script>
+        const data = {
+            periods: [
+                { name: "Risorgimento", start: 1848, end: 1870, color: "linear-gradient(135deg,#2196f3,#21cbf3)", lane: 0 },
+                { name: "Età Umbertina", start: 1878, end: 1900, color: "linear-gradient(135deg,#ffb74d,#ff8a65)", lane: 1 },
+                { name: "Età Giolittiana", start: 1903, end: 1914, color: "linear-gradient(135deg,#ffef62,#ff9800)", lane: 0 },
+                { name: "Grande Guerra", start: 1915, end: 1918, color: "linear-gradient(135deg,#f48fb1,#ba68c8)", lane: 2 },
+                { name: "Dopoguerra e Crisi", start: 1919, end: 1922, color: "linear-gradient(135deg,#64b5f6,#4db6ac)", lane: 1 },
+                { name: "Ventennio Fascista", start: 1922, end: 1943, color: "linear-gradient(135deg,#30cfd0,#330867)", lane: 0 },
+                { name: "Seconda Guerra Mondiale", start: 1940, end: 1945, color: "linear-gradient(135deg,#a8edea,#fed6e3)", lane: 2 },
+                { name: "Transizione alla Repubblica", start: 1943, end: 1948, color: "linear-gradient(135deg,#00f260,#0575e6)", lane: 1 }
+            ],
+            events: [
+                { date: "1848-03-18", title: "Cinque Giornate di Milano", description: "L'insurrezione milanese contro il dominio austriaco dà avvio alla Prima Guerra d'Indipendenza.", level: 1, image: "https://upload.wikimedia.org/wikipedia/commons/e/ec/Indipendenza_italiana_1848.jpg" },
+                { date: "1849-02-09", title: "Repubblica Romana", description: "Mazzini, Garibaldi e Saffi guidano una breve esperienza repubblicana e democratica.", level: 2 },
+                { date: "1859-04-26", title: "Seconda Guerra d'Indipendenza", description: "L'alleanza con la Francia di Napoleone III porta a decisive vittorie contro l'Austria.", level: 2 },
+                { date: "1860-05-05", title: "Spedizione dei Mille", description: "Garibaldi e i volontari partono da Quarto e conquistano il Regno delle Due Sicilie.", level: 1, image: "https://upload.wikimedia.org/wikipedia/commons/3/33/Garibaldi_landing_in_Sicily.jpg" },
+                { date: "1861-03-17", title: "Proclamazione del Regno d'Italia", description: "Vittorio Emanuele II diventa il primo re d'Italia: nasce il nuovo Stato unitario.", level: 1, image: "https://upload.wikimedia.org/wikipedia/commons/b/b3/Proclamazione_del_Regno_d%27Italia.jpg" },
+                { date: "1870-09-20", title: "Breccia di Porta Pia", description: "Roma viene conquistata e diventa capitale d'Italia; termina il potere temporale del Papa.", level: 1, image: "https://upload.wikimedia.org/wikipedia/commons/e/e8/Breccia_di_Porta_Pia.jpg" },
+                { date: "1876-03-25", title: "Governo della Sinistra storica", description: "Agostino Depretis inaugura una stagione di riforme e trasformismo politico.", level: 3 },
+                { date: "1882-05-20", title: "Triplice Alleanza", description: "Italia, Germania e Austria-Ungheria siglano un'alleanza difensiva destinata a durare fino al 1915.", level: 2 },
+                { date: "1896-03-01", title: "Battaglia di Adua", description: "Grave sconfitta in Etiopia che arresta l'espansione coloniale italiana in Africa.", level: 1 },
+                { date: "1909-01-01", title: "Manifesto Futurista", description: "Filippo Tommaso Marinetti pubblica su Le Figaro il manifesto che rivoluziona l'avanguardia artistica.", level: 3 },
+                { date: "1911-09-29", title: "Guerra di Libia", description: "L'Italia dichiara guerra all'Impero Ottomano per il controllo della Tripolitania e della Cirenaica.", level: 2 },
+                { date: "1914-07-28", title: "Neutralità nella Grande Guerra", description: "Allo scoppio del conflitto mondiale l'Italia rimane neutrale nonostante la Triplice Alleanza.", level: 3 },
+                { date: "1915-05-24", title: "Intervento nella Prima Guerra Mondiale", description: "Con il Patto di Londra l'Italia entra in guerra al fianco dell'Intesa.", level: 1, image: "https://upload.wikimedia.org/wikipedia/commons/1/18/Italian_troops_advancing_during_the_Battle_of_the_Piave.jpg" },
+                { date: "1917-10-24", title: "Disfatta di Caporetto", description: "L'esercito italiano è travolto dall'offensiva austro-tedesca, costretto a ritirarsi sul Piave.", level: 2 },
+                { date: "1918-11-04", title: "Vittoria nella Grande Guerra", description: "L'armistizio di Villa Giusti sancisce la fine del conflitto per l'Italia.", level: 2 },
+                { date: "1919-03-23", title: "Fasci di combattimento", description: "Benito Mussolini fonda a Milano il movimento che darà origine al Partito Nazionale Fascista.", level: 2 },
+                { date: "1922-10-28", title: "Marcia su Roma", description: "Le squadre fasciste convergono sulla capitale: il re affida a Mussolini il governo.", level: 1, image: "https://upload.wikimedia.org/wikipedia/commons/9/90/Marcia_su_Roma.jpg" },
+                { date: "1924-06-10", title: "Delitto Matteotti", description: "Il deputato socialista viene rapito e assassinato, scatenando una crisi politica.", level: 2 },
+                { date: "1929-02-11", title: "Patti Lateranensi", description: "L'accordo tra Stato e Chiesa chiude la questione romana e riconosce lo Stato della Città del Vaticano.", level: 1 },
+                { date: "1935-10-03", title: "Guerra d'Etiopia", description: "L'Italia invade l'Etiopia: la conquista porta all'isolamento internazionale.", level: 2 },
+                { date: "1938-09-05", title: "Leggi razziali", description: "Il regime fascista vara provvedimenti discriminatori contro gli ebrei.", level: 1 },
+                { date: "1940-06-10", title: "Entrata nella Seconda Guerra Mondiale", description: "L'Italia dichiara guerra a Francia e Regno Unito al fianco della Germania nazista.", level: 1, image: "https://upload.wikimedia.org/wikipedia/commons/7/7b/Italian_troops_in_North_Africa_1940.jpg" },
+                { date: "1943-07-25", title: "Caduta di Mussolini", description: "Il Gran Consiglio del Fascismo destituisce Mussolini; il maresciallo Badoglio forma un nuovo governo.", level: 1, image: "https://upload.wikimedia.org/wikipedia/commons/b/b3/Benito_Mussolini_arrested_1943.jpg" },
+                { date: "1944-06-04", title: "Liberazione di Roma", description: "Gli Alleati entrano nella capitale, evento simbolo della Resistenza italiana.", level: 2 },
+                { date: "1946-06-02", title: "Referendum Istituzionale", description: "Gli italiani scelgono la Repubblica e per la prima volta votano anche le donne.", level: 1, image: "https://upload.wikimedia.org/wikipedia/commons/1/13/Voting_in_Italy_1946.jpg" },
+                { date: "1947-02-10", title: "Trattato di Parigi", description: "L'Italia firma le condizioni di pace con gli Alleati dopo la Seconda Guerra Mondiale.", level: 2 },
+                { date: "1948-01-01", title: "Entrata in vigore della Costituzione", description: "La Costituzione repubblicana diventa legge fondamentale dello Stato.", level: 1, image: "https://upload.wikimedia.org/wikipedia/commons/b/b1/Italian_Constitution_1948.jpg" }
+            ]
+        };
+
+        const state = {
+            zoom: 1,
+            minZoom: 0.35,
+            maxZoom: 4,
+            translate: 0,
+            isPointerDown: false,
+            pointerStartX: 0,
+            translateStart: 0,
+            timelineWidth: 0
+        };
+
+        const root = document.documentElement;
+        const shell = document.querySelector('.timeline-shell');
+        const wrapper = document.querySelector('.timeline-wrapper');
+        const inner = document.querySelector('.timeline-inner');
+        const mainLine = document.querySelector('.timeline-main');
+        const zoomLevelEl = document.querySelector('.zoom-level');
+        const zoomButtons = document.querySelectorAll('.zoom-btn');
+        const minimap = document.querySelector('.minimap-track');
+        const minimapViewport = document.querySelector('.minimap-viewport');
+        const yearIndicator = document.querySelector('.year-indicator');
+        const yearBadge = document.querySelector('.year-badge');
+        const particlesLayer = document.querySelector('.bg-particles');
+
+        const parseDate = (value) => {
+            const [year, month = '01', day = '01'] = value.split('-');
+            const y = Number(year);
+            const m = Number(month);
+            const d = Number(day);
+            return y + (m - 1) / 12 + (d - 1) / 365;
+        };
+
+        const allDates = [
+            ...data.periods.flatMap(p => [p.start, p.end]),
+            ...data.events.map(e => parseDate(e.date))
+        ];
+        const minYear = Math.floor(Math.min(...allDates));
+        const maxYear = Math.ceil(Math.max(...allDates));
+        const totalYears = maxYear - minYear;
+        const basePixelsPerYear = 110;
+        const baseWidth = totalYears * basePixelsPerYear;
+
+        inner.style.width = `${baseWidth}px`;
+        mainLine.style.width = `${baseWidth}px`;
+
+        const laneOffsets = [-110, 90, -180];
+        const levelOffsets = { 1: -150, 2: 150, 3: -240 };
+        const tickElements = [];
+
+        const addTicks = () => {
+            for (let year = minYear; year <= maxYear; year++) {
+                const tick = document.createElement('div');
+                tick.className = 'timeline-tick';
+                if (year % 10 === 0) tick.classList.add('major');
+                const position = (year - minYear) / totalYears * baseWidth;
+                tick.style.left = `${position}px`;
+                const label = document.createElement('div');
+                label.className = 'timeline-tick-label';
+                label.textContent = '';
+                tick.appendChild(label);
+                inner.appendChild(tick);
+                tickElements.push({ year, tick, label });
+            }
+        };
+
+        const addPeriods = () => {
+            data.periods.forEach(period => {
+                const el = document.createElement('div');
+                el.className = 'period';
+                el.textContent = period.name;
+                const start = (period.start - minYear) / totalYears * baseWidth;
+                const width = (period.end - period.start) / totalYears * baseWidth;
+                el.style.left = `${start}px`;
+                el.style.width = `${width}px`;
+                const laneOffset = laneOffsets[period.lane] ?? 0;
+                el.style.top = `calc(50% + ${laneOffset}px)`;
+                el.style.background = period.color;
+                inner.appendChild(el);
+
+                const mini = document.createElement('div');
+                mini.className = 'minimap-period';
+                mini.style.background = period.color;
+                mini.style.left = `${start / baseWidth * 100}%`;
+                mini.style.width = `${width / baseWidth * 100}%`;
+                mini.style.top = `${50 + (period.lane * 18)}%`;
+                minimap.appendChild(mini);
+            });
+        };
+
+        const addEvents = () => {
+            data.events.forEach(event => {
+                const el = document.createElement('div');
+                el.className = 'event';
+                el.dataset.level = event.level;
+                const position = (parseDate(event.date) - minYear) / totalYears * baseWidth;
+                el.style.left = `${position}px`;
+                const levelOffset = levelOffsets[event.level] ?? 0;
+                el.style.setProperty('--event-offset', `${levelOffset}px`);
+                const side = event.level === 2 ? 'bottom' : 'top';
+                el.dataset.side = side;
+
+                const marker = document.createElement('div');
+                marker.className = 'event-marker';
+                el.appendChild(marker);
+
+                const card = document.createElement('div');
+                card.className = 'event-card';
+
+                const date = document.createElement('div');
+                date.className = 'event-date';
+                date.textContent = new Intl.DateTimeFormat('it-IT', { year: 'numeric', month: 'short', day: 'numeric' }).format(new Date(event.date));
+                card.appendChild(date);
+
+                const title = document.createElement('div');
+                title.className = 'event-title';
+                title.textContent = event.title;
+                card.appendChild(title);
+
+                const description = document.createElement('div');
+                description.className = 'event-description';
+                description.textContent = event.description;
+                card.appendChild(description);
+
+                if (event.image) {
+                    const img = document.createElement('img');
+                    img.src = event.image;
+                    img.alt = event.title;
+                    img.loading = 'lazy';
+                    img.className = 'event-image';
+                    card.appendChild(img);
+                }
+
+                el.appendChild(card);
+                inner.appendChild(el);
+
+                const mini = document.createElement('div');
+                mini.className = 'minimap-event';
+                mini.style.left = `${position / baseWidth * 100}%`;
+                minimap.appendChild(mini);
+            });
+        };
+
+        const addParticles = () => {
+            const total = 42;
+            for (let i = 0; i < total; i++) {
+                const particle = document.createElement('div');
+                particle.className = 'particle';
+                particle.style.left = `${Math.random() * 100}%`;
+                particle.style.top = `${Math.random() * 100}%`;
+                particle.style.width = particle.style.height = `${6 + Math.random() * 10}px`;
+                particle.style.animationDuration = `${14 + Math.random() * 10}s`;
+                particle.style.animationDelay = `${Math.random() * 6}s`;
+                particlesLayer.appendChild(particle);
+            }
+        };
+
+        const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+        const updateTransforms = () => {
+            const scaledWidth = baseWidth * state.zoom;
+            const containerWidth = shell.clientWidth;
+            const availableSpace = containerWidth - scaledWidth;
+
+            if (scaledWidth <= containerWidth) {
+                state.translate = availableSpace / 2;
+            } else {
+                const minTranslate = availableSpace;
+                state.translate = clamp(state.translate, minTranslate, 0);
+            }
+
+            wrapper.style.transform = `translateX(${state.translate}px)`;
+            inner.style.transform = `scale(${state.zoom}) translateY(-50%)`;
+            state.timelineWidth = scaledWidth;
+            root.style.setProperty('--timeline-zoom', state.zoom.toFixed(3));
+            const periodScale = clamp(1.35 / state.zoom, 1, 2.1);
+            const eventTextScale = clamp(1.25 / state.zoom, 1, 2.2);
+            const eventCardScale = clamp(1.15 / state.zoom, 1, 1.75);
+            const tickTextScale = clamp(1.1 / state.zoom, 0.95, 2.1);
+            root.style.setProperty('--period-label-scale', periodScale.toFixed(3));
+            root.style.setProperty('--event-text-scale', eventTextScale.toFixed(3));
+            root.style.setProperty('--event-card-scale', eventCardScale.toFixed(3));
+            root.style.setProperty('--tick-text-scale', tickTextScale.toFixed(3));
+            updateZoomLevel();
+            updateDetailLevels();
+            updateTickDetail();
+            updateMinimap();
+            showYearIndicator();
+        };
+
+        const updateZoomLevel = () => {
+            zoomLevelEl.textContent = `${Math.round(state.zoom * 100)}%`;
+        };
+
+        const updateDetailLevels = () => {
+            inner.classList.remove('zoom-low', 'zoom-medium', 'zoom-high');
+            if (state.zoom < 0.7) {
+                inner.classList.add('zoom-low');
+            } else if (state.zoom < 1.6) {
+                inner.classList.add('zoom-medium');
+            } else {
+                inner.classList.add('zoom-high');
+            }
+        };
+
+        const updateTickDetail = () => {
+            if (!tickElements.length) return;
+            let spacing;
+            if (state.zoom >= 2.3) {
+                spacing = 1;
+            } else if (state.zoom >= 1.6) {
+                spacing = 2;
+            } else if (state.zoom >= 1.1) {
+                spacing = 5;
+            } else if (state.zoom >= 0.65) {
+                spacing = 10;
+            } else {
+                spacing = 20;
+            }
+
+            tickElements.forEach(({ year, tick, label }) => {
+                const isMajor = year % 10 === 0;
+                const showLabel = year === minYear || year === maxYear || year % spacing === 0;
+                label.textContent = showLabel ? year : '';
+                tick.classList.toggle('major', isMajor);
+                const emphasizeTick = showLabel || isMajor;
+                const hideTick = state.zoom < 0.65 && !emphasizeTick;
+                tick.style.display = hideTick ? 'none' : 'block';
+                tick.style.opacity = hideTick ? 0 : emphasizeTick ? 1 : 0.35;
+            });
+        };
+
+        const updateMinimap = () => {
+            const scaledWidth = baseWidth * state.zoom;
+            const ratio = shell.clientWidth / scaledWidth;
+            const viewWidth = clamp(ratio, 0.05, 1);
+            minimapViewport.style.width = `${viewWidth * 100}%`;
+            const maxOffset = 1 - viewWidth;
+            const available = Math.max(1, scaledWidth - shell.clientWidth);
+            const offset = available === 0 ? 0 : clamp((-state.translate) / available, 0, 1);
+            minimapViewport.style.left = `${offset * maxOffset * 100}%`;
+        };
+
+        let yearTimeout;
+        const showYearIndicator = () => {
+            const centerPx = -state.translate + shell.clientWidth / 2;
+            const centerRatio = clamp(centerPx / (baseWidth * state.zoom), 0, 1);
+            const yearValue = minYear + centerRatio * totalYears;
+            yearBadge.textContent = Math.round(yearValue);
+            yearIndicator.classList.add('show');
+            clearTimeout(yearTimeout);
+            yearTimeout = setTimeout(() => yearIndicator.classList.remove('show'), 800);
+        };
+
+        const zoomTo = (factor, originX) => {
+            const previousZoom = state.zoom;
+            state.zoom = clamp(state.zoom * factor, state.minZoom, state.maxZoom);
+            const scaleChange = state.zoom / previousZoom;
+            const rect = shell.getBoundingClientRect();
+            const origin = originX !== undefined ? originX - rect.left : rect.width / 2;
+            state.translate = origin - scaleChange * (origin - state.translate);
+            updateTransforms();
+        };
+
+        zoomButtons.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const direction = btn.dataset.action === 'in' ? 1 : -1;
+                const factor = direction > 0 ? 1.25 : 0.8;
+                zoomTo(factor);
+            });
+        });
+
+        shell.addEventListener('wheel', (event) => {
+            if (!event.ctrlKey) {
+                event.preventDefault();
+                const factor = event.deltaY > 0 ? 0.92 : 1.08;
+                zoomTo(factor, event.clientX);
+            }
+        }, { passive: false });
+
+        shell.addEventListener('pointerdown', (event) => {
+            state.isPointerDown = true;
+            state.pointerStartX = event.clientX;
+            state.translateStart = state.translate;
+            shell.classList.add('dragging');
+            shell.setPointerCapture(event.pointerId);
+        });
+
+        shell.addEventListener('pointermove', (event) => {
+            if (!state.isPointerDown) return;
+            const delta = event.clientX - state.pointerStartX;
+            state.translate = state.translateStart + delta;
+            updateTransforms();
+        });
+
+        const endPointer = (event) => {
+            if (!state.isPointerDown) return;
+            state.isPointerDown = false;
+            shell.classList.remove('dragging');
+            shell.releasePointerCapture(event.pointerId);
+        };
+
+        shell.addEventListener('pointerup', endPointer);
+        shell.addEventListener('pointercancel', endPointer);
+
+        const moveViewportToRatio = (ratio) => {
+            const scaledWidth = baseWidth * state.zoom;
+            if (scaledWidth <= shell.clientWidth) return;
+            const maxTranslate = 0;
+            const minTranslate = shell.clientWidth - scaledWidth;
+            state.translate = clamp(-ratio * (scaledWidth - shell.clientWidth), minTranslate, maxTranslate);
+            updateTransforms();
+        };
+
+        minimapViewport.addEventListener('pointerdown', (event) => {
+            event.preventDefault();
+            const rect = minimap.getBoundingClientRect();
+            const viewportRect = minimapViewport.getBoundingClientRect();
+            const offsetWithin = event.clientX - viewportRect.left;
+
+            const move = (clientX) => {
+                const rawRatio = (clientX - rect.left - offsetWithin) / (rect.width - viewportRect.width);
+                moveViewportToRatio(clamp(rawRatio, 0, 1));
+            };
+
+            const onPointerMove = (moveEvent) => move(moveEvent.clientX);
+            const onPointerUp = () => {
+                document.removeEventListener('pointermove', onPointerMove);
+                document.removeEventListener('pointerup', onPointerUp);
+            };
+
+            document.addEventListener('pointermove', onPointerMove);
+            document.addEventListener('pointerup', onPointerUp);
+        });
+
+        minimap.addEventListener('pointerdown', (event) => {
+            if (event.target === minimapViewport) return;
+            const rect = minimap.getBoundingClientRect();
+            const viewRatio = minimapViewport.offsetWidth / rect.width;
+            const availableRatio = Math.max(0, 1 - viewRatio);
+            const rawRatio = clamp((event.clientX - rect.left) / rect.width, 0, 1);
+            const targetRatio = availableRatio === 0 ? 0 : clamp(rawRatio - viewRatio / 2, 0, availableRatio) / availableRatio;
+            moveViewportToRatio(targetRatio);
+        });
+
+        window.addEventListener('resize', () => {
+            updateTransforms();
+        });
+
+        const init = () => {
+            addParticles();
+            addTicks();
+            addPeriods();
+            addEvents();
+            updateTransforms();
+        };
+
+        init();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- keep period labels, tick labels, and event popups legible by scaling typography and layout with the current zoom factor
- reposition event markers by level and adjust popup orientation so their clickable points are clearer across tracks
- introduce adaptive tick density that collapses labels from yearly to quinquennial or decennial markers as the user zooms out

## Testing
- Manual verification in browser


------
https://chatgpt.com/codex/tasks/task_e_68e670cfa7088326a0ac6f1fbc794537