### PR TITLE
Add Regno d'Italia period and ease zoom-out readability

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -156,6 +156,7 @@ h1 {
     transform-origin: left center;
     transform: translateY(-50%) scale(1, 1);
     will-change: transform;
+    --timeline-font-scale: 1;
 }
 
 .timeline-main {
@@ -187,7 +188,7 @@ h1 {
     bottom: -46px;
     left: 50%;
     transform: translateX(-50%);
-    font-size: 0.75rem;
+    font-size: calc(0.75rem * var(--timeline-font-scale, 1));
     color: rgba(255,255,255,0.75);
     white-space: nowrap;
 }
@@ -196,10 +197,10 @@ h1 {
     position: absolute;
     transform: translateY(-50%);
     border-radius: 14px;
-    padding: 8px 20px;
+    padding: 8px calc(20px * var(--timeline-font-scale, 1));
     color: #fff;
     font-weight: 600;
-    font-size: 0.9rem;
+    font-size: calc(0.9rem * var(--timeline-font-scale, 1));
     backdrop-filter: blur(10px);
     box-shadow: 0 10px 30px rgba(0,0,0,0.35);
     transition: transform 0.2s ease, opacity 0.2s ease;

--- a/assets/js/timeline-data.js
+++ b/assets/js/timeline-data.js
@@ -3,6 +3,7 @@ window.TIMELINE_DATA = {
         { name: "Età della Restaurazione", start: 1815, end: 1830, color: "rgba(121,134,203,0.45)", lane: 2 },
         { name: "Moti rivoluzionari e prime riforme", start: 1831, end: 1847, color: "rgba(121,134,203,0.45)", lane: 0 },
         { name: "Risorgimento e Unità d'Italia", start: 1848, end: 1870, color: "rgba(244,143,177,0.45)", lane: 1 },
+        { name: "Regno d'Italia", start: 1861, end: 1946, color: "rgba(244,143,177,0.32)", lane: 3 },
         { name: "Età Umbertina", start: 1878, end: 1900, color: "rgba(129,212,250,0.45)", lane: 0 },
         { name: "Età Giolittiana", start: 1903, end: 1914, color: "rgba(129,212,250,0.45)", lane: 2 },
         { name: "Grande Guerra", start: 1914, end: 1918, color: "rgba(255,214,126,0.45)", lane: 1 },

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -54,14 +54,16 @@ document.addEventListener('DOMContentLoaded', () => {
     inner.style.width = `${baseWidth}px`;
     mainLine.style.width = `${baseWidth}px`;
 
-    const laneOffsets = [-110, 90, -180];
+    const laneOffsets = [-110, 90, -180, 200];
+    const minimapLaneBase = 35;
+    const minimapLaneSpacing = 15;
     const levelOffsets = { 1: 0, 2: -110, 3: -200 };
 
     const tickElements = [];
 
     const tickConfigs = [
         {
-            maxZoom: 0.6,
+            maxZoom: 0.45,
             step: 100,
             majorStep: 100,
             formatLabel: (year) => {
@@ -76,19 +78,24 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         },
         {
-            maxZoom: 0.85,
+            maxZoom: 0.75,
             step: 50,
-            majorStep: 100
-        },
-        {
-            maxZoom: 1.4,
-            step: 10,
             majorStep: 50
         },
         {
-            maxZoom: 2.4,
+            maxZoom: 1.2,
+            step: 25,
+            majorStep: 50
+        },
+        {
+            maxZoom: 1.8,
+            step: 10,
+            majorStep: 20
+        },
+        {
+            maxZoom: 2.6,
             step: 5,
-            majorStep: 25
+            majorStep: 10
         },
         {
             maxZoom: Infinity,
@@ -164,7 +171,7 @@ document.addEventListener('DOMContentLoaded', () => {
             mini.style.background = period.color;
             mini.style.left = `${(start / baseWidth) * 100}%`;
             mini.style.width = `${(width / baseWidth) * 100}%`;
-            mini.style.top = `${50 + period.lane * 18}%`;
+            mini.style.top = `${minimapLaneBase + period.lane * minimapLaneSpacing}%`;
             minimap.appendChild(mini);
 
             const miniLabel = document.createElement('div');
@@ -254,9 +261,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const updateDetailLevels = () => {
         inner.classList.remove('zoom-low', 'zoom-medium', 'zoom-high');
-        if (state.zoom < 0.7) {
+        if (state.zoom < 0.55) {
             inner.classList.add('zoom-low');
-        } else if (state.zoom < 1.6) {
+        } else if (state.zoom < 1.3) {
             inner.classList.add('zoom-medium');
         } else {
             inner.classList.add('zoom-high');
@@ -300,6 +307,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         wrapper.style.transform = `translateX(${state.translate}px)`;
         inner.style.transform = `translateY(-50%) scale(${state.zoom}, 1)`;
+        const textScale = clamp(1 / state.zoom, 1, 2.3);
+        inner.style.setProperty('--timeline-font-scale', textScale.toFixed(3));
         state.timelineWidth = scaledWidth;
         updateZoomLevel();
         updateDetailLevels();


### PR DESCRIPTION
## Summary
- add the Regno d'Italia period (1861-1946) to the data set and place it on its own lane
- rebalance zoom thresholds so year ticks retain more detail while zoomed out
- scale timeline typography responsively to preserve label readability during zoom changes

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e68697f5348326abc6d308c63713b4