### PR TITLE
Add light/dark theme support with toggle

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -1,3 +1,97 @@
+:root {
+    --bg-gradient: radial-gradient(circle at top, rgba(103, 58, 183, 0.25), transparent 45%),
+        radial-gradient(circle at bottom, rgba(3, 169, 244, 0.25), transparent 40%),
+        linear-gradient(135deg, #080b24 0%, #14183a 35%, #10152b 100%);
+    --text-primary: #f5f7ff;
+    --text-secondary: rgba(235, 240, 255, 0.85);
+    --accent-primary: #8d9eff;
+    --header-bg: rgba(8, 11, 36, 0.75);
+    --header-border: rgba(255, 255, 255, 0.08);
+    --control-surface: rgba(255, 255, 255, 0.08);
+    --control-border: rgba(255, 255, 255, 0.08);
+    --control-hover: rgba(255, 255, 255, 0.12);
+    --control-text: #f5f7ff;
+    --timeline-line-gradient: linear-gradient(90deg, rgba(141, 158, 255, 0.9), rgba(244, 143, 177, 0.9));
+    --timeline-line-glow: rgba(120, 140, 255, 0.5);
+    --tick-color: rgba(255, 255, 255, 0.3);
+    --tick-major-color: rgba(255, 255, 255, 0.6);
+    --tick-label-color: rgba(255, 255, 255, 0.75);
+    --period-text-color: #ffffff;
+    --period-shadow: rgba(0, 0, 0, 0.35);
+    --event-marker-gradient: linear-gradient(135deg, #ffffff, #c5cae9);
+    --event-marker-outline: rgba(255, 255, 255, 0.4);
+    --event-marker-glow: rgba(255, 255, 255, 0.75);
+    --event-card-bg: rgba(8, 11, 36, 0.95);
+    --event-card-border: rgba(255, 255, 255, 0.08);
+    --event-card-title: #ffffff;
+    --event-card-description: rgba(235, 240, 255, 0.85);
+    --event-image-border: rgba(255, 255, 255, 0.06);
+    --minimap-bg: rgba(8, 11, 36, 0.82);
+    --minimap-border: rgba(255, 255, 255, 0.08);
+    --minimap-track-bg: rgba(255, 255, 255, 0.08);
+    --minimap-event-color: rgba(255, 255, 255, 0.7);
+    --minimap-label-color: rgba(255, 255, 255, 0.78);
+    --minimap-label-shadow: rgba(5, 7, 19, 0.6);
+    --minimap-viewport-border: rgba(141, 158, 255, 0.85);
+    --minimap-viewport-bg: rgba(141, 158, 255, 0.2);
+    --year-badge-bg: rgba(141, 158, 255, 0.9);
+    --year-badge-text: #050713;
+    --year-badge-shadow: rgba(141, 158, 255, 0.4);
+    --particle-color: radial-gradient(circle, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0) 70%);
+    --toggle-bg: rgba(255, 255, 255, 0.08);
+    --toggle-border: rgba(255, 255, 255, 0.12);
+    --toggle-thumb: #f5f7ff;
+    --toggle-icon-dark: #f5f7ff;
+    --toggle-icon-light: #f5f7ff;
+}
+
+:root[data-theme="light"] {
+    --bg-gradient: radial-gradient(circle at top, rgba(103, 58, 183, 0.12), transparent 45%),
+        radial-gradient(circle at bottom, rgba(3, 169, 244, 0.12), transparent 40%),
+        linear-gradient(135deg, #f5f8ff 0%, #ecf1ff 40%, #f7f1ff 100%);
+    --text-primary: #1a1b2e;
+    --text-secondary: rgba(40, 45, 70, 0.78);
+    --accent-primary: #5c6bc0;
+    --header-bg: rgba(255, 255, 255, 0.85);
+    --header-border: rgba(46, 64, 128, 0.12);
+    --control-surface: rgba(46, 64, 128, 0.08);
+    --control-border: rgba(46, 64, 128, 0.12);
+    --control-hover: rgba(46, 64, 128, 0.18);
+    --control-text: #1a1b2e;
+    --timeline-line-gradient: linear-gradient(90deg, rgba(121, 134, 203, 0.85), rgba(244, 143, 177, 0.85));
+    --timeline-line-glow: rgba(121, 134, 203, 0.35);
+    --tick-color: rgba(26, 27, 46, 0.15);
+    --tick-major-color: rgba(26, 27, 46, 0.3);
+    --tick-label-color: rgba(26, 27, 46, 0.7);
+    --period-text-color: #1a1b2e;
+    --period-shadow: rgba(122, 130, 180, 0.25);
+    --event-marker-gradient: linear-gradient(135deg, #5c6bc0, #9fa8da);
+    --event-marker-outline: rgba(92, 107, 192, 0.35);
+    --event-marker-glow: rgba(92, 107, 192, 0.45);
+    --event-card-bg: rgba(255, 255, 255, 0.94);
+    --event-card-border: rgba(46, 64, 128, 0.12);
+    --event-card-title: #1a1b2e;
+    --event-card-description: rgba(40, 45, 70, 0.75);
+    --event-image-border: rgba(46, 64, 128, 0.12);
+    --minimap-bg: rgba(255, 255, 255, 0.85);
+    --minimap-border: rgba(46, 64, 128, 0.12);
+    --minimap-track-bg: rgba(46, 64, 128, 0.12);
+    --minimap-event-color: rgba(26, 27, 46, 0.55);
+    --minimap-label-color: rgba(26, 27, 46, 0.68);
+    --minimap-label-shadow: rgba(255, 255, 255, 0.7);
+    --minimap-viewport-border: rgba(92, 107, 192, 0.8);
+    --minimap-viewport-bg: rgba(92, 107, 192, 0.18);
+    --year-badge-bg: rgba(92, 107, 192, 0.92);
+    --year-badge-text: #ffffff;
+    --year-badge-shadow: rgba(92, 107, 192, 0.35);
+    --particle-color: radial-gradient(circle, rgba(92, 107, 192, 0.65) 0%, rgba(92, 107, 192, 0) 70%);
+    --toggle-bg: rgba(46, 64, 128, 0.1);
+    --toggle-border: rgba(46, 64, 128, 0.18);
+    --toggle-thumb: #f5f8ff;
+    --toggle-icon-dark: #394472;
+    --toggle-icon-light: #f0b429;
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -6,12 +100,16 @@
 
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    background: radial-gradient(circle at top, rgba(103, 58, 183, 0.25), transparent 45%),
-                radial-gradient(circle at bottom, rgba(3, 169, 244, 0.25), transparent 40%),
-                linear-gradient(135deg, #080b24 0%, #14183a 35%, #10152b 100%);
+    background: var(--bg-gradient);
     min-height: 100vh;
-    color: #f5f7ff;
+    color: var(--text-primary);
     overflow: hidden;
+    transition: background 0.4s ease, color 0.3s ease;
+    color-scheme: dark;
+}
+
+:root[data-theme="light"] body {
+    color-scheme: light;
 }
 
 .bg-particles {
@@ -27,7 +125,7 @@ body {
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: radial-gradient(circle, rgba(255,255,255,0.9) 0%, rgba(255,255,255,0) 70%);
+    background: var(--particle-color);
     animation: float 16s infinite ease-in-out;
     filter: blur(0.3px);
 }
@@ -50,8 +148,8 @@ header {
     gap: 24px;
     z-index: 3;
     backdrop-filter: blur(18px);
-    background: rgba(8, 11, 36, 0.75);
-    border-bottom: 1px solid rgba(255,255,255,0.08);
+    background: var(--header-bg);
+    border-bottom: 1px solid var(--header-border);
 }
 
 h1 {
@@ -70,12 +168,97 @@ h1 {
     align-items: center;
 }
 
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.theme-toggle {
+    position: relative;
+    width: 66px;
+    height: 34px;
+    border-radius: 999px;
+    border: 1px solid var(--toggle-border);
+    background: var(--toggle-bg);
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 10px;
+    cursor: pointer;
+    transition: background 0.3s ease, border-color 0.3s ease, transform 0.2s ease;
+    appearance: none;
+    color: var(--control-text);
+}
+
+.theme-toggle::after {
+    content: '';
+    position: absolute;
+    top: 4px;
+    bottom: 4px;
+    width: 26px;
+    border-radius: 999px;
+    background: var(--toggle-thumb);
+    box-shadow: 0 6px 14px rgba(15, 20, 40, 0.25);
+    transform: translateX(0);
+    transition: transform 0.3s ease;
+}
+
+.theme-toggle:hover {
+    transform: translateY(-1px);
+    background: var(--control-hover);
+}
+
+.theme-toggle:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 3px;
+}
+
+.theme-toggle__icon {
+    font-size: 1.1rem;
+    line-height: 1;
+    position: relative;
+    z-index: 1;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    pointer-events: none;
+}
+
+.theme-toggle__icon--moon {
+    color: var(--toggle-icon-dark);
+}
+
+.theme-toggle__icon--sun {
+    color: var(--toggle-icon-light);
+}
+
+.theme-toggle[data-theme='light']::after {
+    transform: translateX(30px);
+}
+
+.theme-toggle[data-theme='dark'] .theme-toggle__icon--sun,
+.theme-toggle[data-theme='light'] .theme-toggle__icon--moon {
+    opacity: 0.45;
+    transform: scale(0.9);
+}
+
+.theme-toggle[data-theme='light'] .theme-toggle__icon--sun,
+.theme-toggle[data-theme='dark'] .theme-toggle__icon--moon {
+    opacity: 1;
+    transform: scale(1);
+}
+
 .zoom-controls {
     display: flex;
     align-items: center;
     border-radius: 999px;
-    background: rgba(255,255,255,0.08);
-    border: 1px solid rgba(255,255,255,0.08);
+    background: var(--control-surface);
+    border: 1px solid var(--control-border);
     overflow: hidden;
     box-shadow: 0 12px 30px rgba(10, 20, 60, 0.25);
 }
@@ -83,7 +266,7 @@ h1 {
 .zoom-btn {
     background: none;
     border: none;
-    color: #f5f7ff;
+    color: var(--control-text);
     padding: 10px 18px;
     font-size: 1.4rem;
     cursor: pointer;
@@ -91,28 +274,29 @@ h1 {
 }
 
 .zoom-btn:hover {
-    background: rgba(255,255,255,0.12);
+    background: var(--control-hover);
     transform: translateY(-1px);
 }
 
 .zoom-level {
     padding: 10px 18px;
     font-size: 0.9rem;
-    color: rgba(255,255,255,0.85);
+    color: var(--text-secondary);
     font-weight: 600;
-    border-left: 1px solid rgba(255,255,255,0.06);
-    border-right: 1px solid rgba(255,255,255,0.06);
+    border-left: 1px solid var(--control-border);
+    border-right: 1px solid var(--control-border);
 }
 
 .legend {
     display: flex;
     gap: 16px;
     align-items: center;
-    background: rgba(255,255,255,0.08);
+    background: var(--control-surface);
     padding: 10px 18px;
     border-radius: 999px;
     font-size: 0.9rem;
-    border: 1px solid rgba(255,255,255,0.08);
+    border: 1px solid var(--control-border);
+    color: var(--text-secondary);
 }
 
 .legend span {
@@ -166,21 +350,21 @@ h1 {
     height: 4px;
     transform: translateY(-50%);
     border-radius: 999px;
-    background: linear-gradient(90deg, rgba(141,158,255,0.9), rgba(244,143,177,0.9));
-    box-shadow: 0 0 24px rgba(120,140,255,0.5);
+    background: var(--timeline-line-gradient);
+    box-shadow: 0 0 24px var(--timeline-line-glow);
 }
 
 .timeline-tick {
     position: absolute;
     bottom: -22px;
     width: 2px;
-    background: rgba(255,255,255,0.3);
+    background: var(--tick-color);
     height: 14px;
 }
 
 .timeline-tick.major {
     height: 26px;
-    background: rgba(255,255,255,0.6);
+    background: var(--tick-major-color);
 }
 
 .timeline-tick-label {
@@ -189,7 +373,7 @@ h1 {
     left: 50%;
     transform: translateX(-50%);
     font-size: calc(0.75rem * var(--timeline-font-scale, 1));
-    color: rgba(255,255,255,0.75);
+    color: var(--tick-label-color);
     white-space: nowrap;
 }
 
@@ -198,11 +382,11 @@ h1 {
     transform: translateY(-50%);
     border-radius: 14px;
     padding: 8px calc(20px * var(--timeline-font-scale, 1));
-    color: #fff;
+    color: var(--period-text-color);
     font-weight: 600;
     font-size: calc(0.9rem * var(--timeline-font-scale, 1));
     backdrop-filter: blur(10px);
-    box-shadow: 0 10px 30px rgba(0,0,0,0.35);
+    box-shadow: 0 10px 30px var(--period-shadow);
     transition: transform 0.2s ease, opacity 0.2s ease;
     opacity: 0.9;
 }
@@ -226,8 +410,8 @@ h1 {
     width: 16px;
     height: 16px;
     border-radius: 50%;
-    background: linear-gradient(135deg, #ffffff, #c5cae9);
-    box-shadow: 0 0 16px rgba(255,255,255,0.75);
+    background: var(--event-marker-gradient);
+    box-shadow: 0 0 16px var(--event-marker-glow);
     position: relative;
 }
 
@@ -236,7 +420,7 @@ h1 {
     position: absolute;
     inset: -10px;
     border-radius: 50%;
-    border: 1px solid rgba(255,255,255,0.4);
+    border: 1px solid var(--event-marker-outline);
     opacity: 0;
     transform: scale(0.6);
     transition: transform 0.3s ease, opacity 0.3s ease;
@@ -259,10 +443,10 @@ h1 {
     transform-origin: bottom;
     min-width: 260px;
     max-width: 320px;
-    background: rgba(8,11,36,0.95);
+    background: var(--event-card-bg);
     border-radius: 16px;
     padding: 18px 20px;
-    border: 1px solid rgba(255,255,255,0.08);
+    border: 1px solid var(--event-card-border);
     box-shadow: 0 24px 50px rgba(0,0,0,0.45);
     opacity: 0;
     pointer-events: none;
@@ -278,7 +462,7 @@ h1 {
     font-size: 0.75rem;
     letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: #8d9eff;
+    color: var(--accent-primary);
     margin-bottom: 6px;
 }
 
@@ -286,13 +470,13 @@ h1 {
     font-size: 1.05rem;
     font-weight: 700;
     margin-bottom: 8px;
-    color: #fff;
+    color: var(--event-card-title);
 }
 
 .event-description {
     font-size: 0.9rem;
     line-height: 1.55;
-    color: rgba(235,240,255,0.85);
+    color: var(--event-card-description);
 }
 
 .event-image {
@@ -301,7 +485,7 @@ h1 {
     object-fit: cover;
     border-radius: 12px;
     margin-top: 14px;
-    border: 1px solid rgba(255,255,255,0.06);
+    border: 1px solid var(--event-image-border);
 }
 
 .timeline-inner.zoom-low .event[data-level="2"],
@@ -327,8 +511,8 @@ h1 {
     width: min(90vw, 960px);
     height: 104px;
     border-radius: 32px;
-    background: rgba(8,11,36,0.82);
-    border: 1px solid rgba(255,255,255,0.08);
+    background: var(--minimap-bg);
+    border: 1px solid var(--minimap-border);
     padding: 16px 24px 24px;
     display: flex;
     align-items: stretch;
@@ -341,7 +525,7 @@ h1 {
     flex: 1;
     height: 100%;
     border-radius: 18px;
-    background: rgba(255,255,255,0.08);
+    background: var(--minimap-track-bg);
     overflow: hidden;
 }
 
@@ -351,7 +535,7 @@ h1 {
     width: 4px;
     height: 4px;
     border-radius: 50%;
-    background: rgba(255,255,255,0.7);
+    background: var(--minimap-event-color);
     transform: translate(-50%, -50%);
 }
 
@@ -372,14 +556,14 @@ h1 {
     padding-left: 8px;
     font-size: 0.65rem;
     font-weight: 600;
-    color: rgba(255,255,255,0.78);
+    color: var(--minimap-label-color);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     pointer-events: none;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    text-shadow: 0 2px 10px rgba(5,7,19,0.6);
+    text-shadow: 0 2px 10px var(--minimap-label-shadow);
     z-index: 2;
 }
 
@@ -388,8 +572,8 @@ h1 {
     top: 0;
     bottom: 0;
     border-radius: 16px;
-    border: 2px solid rgba(141,158,255,0.85);
-    background: rgba(141,158,255,0.2);
+    border: 2px solid var(--minimap-viewport-border);
+    background: var(--minimap-viewport-bg);
     cursor: grab;
     transition: none;
 }
@@ -412,11 +596,11 @@ h1 {
 .year-badge {
     padding: 12px 28px;
     border-radius: 999px;
-    background: rgba(141,158,255,0.9);
-    color: #050713;
+    background: var(--year-badge-bg);
+    color: var(--year-badge-text);
     font-size: 1.4rem;
     font-weight: 700;
-    box-shadow: 0 20px 50px rgba(141,158,255,0.4);
+    box-shadow: 0 20px 50px var(--year-badge-shadow);
 }
 
 @media (max-width: 860px) {

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -27,6 +27,79 @@ document.addEventListener('DOMContentLoaded', () => {
     const yearIndicator = document.querySelector('.year-indicator');
     const yearBadge = document.querySelector('.year-badge');
     const particlesLayer = document.querySelector('.bg-particles');
+    const themeToggle = document.querySelector('.theme-toggle');
+    const rootElement = document.documentElement;
+    const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+    const themeStorageKey = 'timeline-theme';
+
+    const normalizeTheme = (value) => {
+        if (value === 'light' || value === 'dark') {
+            return value;
+        }
+        return null;
+    };
+
+    const updateToggleLabels = (theme) => {
+        if (!themeToggle) return;
+        const nextTheme = theme === 'light' ? 'dark' : 'light';
+        const label = nextTheme === 'light' ? 'Attiva tema chiaro' : 'Attiva tema scuro';
+        themeToggle.dataset.theme = theme;
+        themeToggle.setAttribute('aria-label', label);
+        themeToggle.setAttribute('aria-pressed', String(theme === 'light'));
+        const srLabel = themeToggle.querySelector('.sr-only');
+        if (srLabel) {
+            srLabel.textContent = label;
+        }
+    };
+
+    const applyTheme = (theme) => {
+        const active = theme === 'light' ? 'light' : 'dark';
+        if (active === 'light') {
+            rootElement.setAttribute('data-theme', 'light');
+        } else {
+            rootElement.removeAttribute('data-theme');
+        }
+        updateToggleLabels(active);
+    };
+
+    let storedTheme = null;
+    try {
+        storedTheme = normalizeTheme(localStorage.getItem(themeStorageKey));
+    } catch (error) {
+        console.warn('Impossibile accedere alle preferenze del tema.', error);
+    }
+
+    let userPreference = storedTheme !== null;
+    let activeTheme = userPreference
+        ? storedTheme
+        : (prefersDarkScheme.matches ? 'dark' : 'light');
+
+    applyTheme(activeTheme);
+
+    const handleSystemThemeChange = (event) => {
+        if (userPreference) return;
+        activeTheme = event.matches ? 'dark' : 'light';
+        applyTheme(activeTheme);
+    };
+
+    if (typeof prefersDarkScheme.addEventListener === 'function') {
+        prefersDarkScheme.addEventListener('change', handleSystemThemeChange);
+    } else if (typeof prefersDarkScheme.addListener === 'function') {
+        prefersDarkScheme.addListener(handleSystemThemeChange);
+    }
+
+    if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+            activeTheme = activeTheme === 'dark' ? 'light' : 'dark';
+            userPreference = true;
+            try {
+                localStorage.setItem(themeStorageKey, activeTheme);
+            } catch (error) {
+                console.warn('Impossibile salvare la preferenza del tema.', error);
+            }
+            applyTheme(activeTheme);
+        });
+    }
 
     if (!shell || !wrapper || !inner || !mainLine) {
         console.error('Missing timeline container elements.');

--- a/index.html
+++ b/index.html
@@ -18,6 +18,11 @@
                 <div class="zoom-level">100%</div>
                 <button class="zoom-btn" data-action="in" aria-label="Aumenta zoom">+</button>
             </div>
+            <button class="theme-toggle" type="button" data-theme="dark" aria-pressed="false" aria-label="Attiva tema chiaro">
+                <span class="sr-only">Attiva tema chiaro</span>
+                <span class="theme-toggle__icon theme-toggle__icon--moon" aria-hidden="true">🌙</span>
+                <span class="theme-toggle__icon theme-toggle__icon--sun" aria-hidden="true">☀️</span>
+            </button>
             <div class="legend">
                 <span><i style="background: rgba(121,134,203,0.6);"></i> Restaurazione e Moti</span>
                 <span><i style="background: rgba(244,143,177,0.6);"></i> Risorgimento</span>


### PR DESCRIPTION
## Summary
- introduce a CSS variable system to drive both dark and light themes
- add a header toggle that switches themes and persists the preference
- update timeline elements so cards, markers, minimap, and badges react to the active theme

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e688e644048326a81e59efd319862a