### PR TITLE
Fix zoom distortion on timeline markers

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -341,6 +341,8 @@ h1 {
     transform: translateY(-50%) scale(1, 1);
     will-change: transform;
     --timeline-font-scale: 1;
+    --timeline-zoom: 1;
+    --timeline-zoom-inverse: 1;
 }
 
 .timeline-main {
@@ -413,6 +415,8 @@ h1 {
     background: var(--event-marker-gradient);
     box-shadow: 0 0 16px var(--event-marker-glow);
     position: relative;
+    transform: scaleX(var(--timeline-zoom-inverse, 1));
+    transform-origin: center;
 }
 
 .event-marker::before {
@@ -422,7 +426,7 @@ h1 {
     border-radius: 50%;
     border: 1px solid var(--event-marker-outline);
     opacity: 0;
-    transform: scale(0.6);
+    transform: scale(0.6) scaleX(var(--timeline-zoom-inverse, 1));
     transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
@@ -432,14 +436,14 @@ h1 {
 
 .event:hover .event-marker::before {
     opacity: 1;
-    transform: scale(1);
+    transform: scale(1) scaleX(var(--timeline-zoom-inverse, 1));
 }
 
 .event-card {
     position: absolute;
     left: 50%;
     bottom: calc(100% + 18px);
-    transform: translate(-50%, 12px) scale(0.95);
+    transform: translate(-50%, 12px) scale(0.95) scaleX(var(--timeline-zoom-inverse, 1));
     transform-origin: bottom;
     min-width: 260px;
     max-width: 320px;
@@ -455,7 +459,7 @@ h1 {
 
 .event:hover .event-card {
     opacity: 1;
-    transform: translate(-50%, 0) scale(1);
+    transform: translate(-50%, 0) scale(1) scaleX(var(--timeline-zoom-inverse, 1));
 }
 
 .event-date {

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -136,7 +136,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const tickConfigs = [
         {
-            maxZoom: 0.45,
+            maxZoom: 0.4,
             step: 100,
             majorStep: 100,
             formatLabel: (year) => {
@@ -151,22 +151,22 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         },
         {
-            maxZoom: 0.75,
+            maxZoom: 0.65,
             step: 50,
             majorStep: 50
         },
         {
-            maxZoom: 1.2,
+            maxZoom: 1,
             step: 25,
             majorStep: 50
         },
         {
-            maxZoom: 1.8,
+            maxZoom: 1.6,
             step: 10,
             majorStep: 20
         },
         {
-            maxZoom: 2.6,
+            maxZoom: 2.4,
             step: 5,
             majorStep: 10
         },
@@ -382,6 +382,8 @@ document.addEventListener('DOMContentLoaded', () => {
         inner.style.transform = `translateY(-50%) scale(${state.zoom}, 1)`;
         const textScale = clamp(1 / state.zoom, 1, 2.3);
         inner.style.setProperty('--timeline-font-scale', textScale.toFixed(3));
+        inner.style.setProperty('--timeline-zoom', state.zoom.toFixed(3));
+        inner.style.setProperty('--timeline-zoom-inverse', (1 / state.zoom).toFixed(3));
         state.timelineWidth = scaledWidth;
         updateZoomLevel();
         updateDetailLevels();


### PR DESCRIPTION
## Summary
- prevent zoom from distorting event markers and popups by applying inverse scaling variables
- expose timeline zoom variables for styling adjustments
- adjust tick visibility thresholds so year and quinquennium labels stay visible longer while zooming out

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e68ca998f48326b8d375f748ba804e