### PR TITLE
Prevent period text shrinking on zoom out

### DIFF
--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -361,8 +361,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const compensated = Math.pow(zoom, -0.35);
             return clamp(compensated, 0.85, 1);
         }
-        const expanded = Math.pow(1 / zoom, 0.78);
-        return clamp(expanded, 1, 3.6);
+        const compensated = 1 / zoom;
+        return clamp(compensated, 1, 5);
     };
 
     const updateDetailLevels = () => {


### PR DESCRIPTION
## Summary
- adjust the text scaling logic so period labels stay legible when zooming out

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6d3b254fc8326924c4a54db338c08