### PR TITLE
Center period descriptions and stabilize zoom scaling

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -386,6 +386,8 @@ h1 {
     padding: 8px clamp(16px, 18px + 0.4vw, 28px);
     display: inline-flex;
     align-items: center;
+    justify-content: center;
+    text-align: center;
     color: var(--period-text-color);
     font-weight: 600;
     font-size: clamp(0.9rem, 0.85rem + 0.35vw, 1.2rem);
@@ -399,6 +401,8 @@ h1 {
     display: inline-flex;
     align-items: center;
     gap: clamp(8px, calc(10px * var(--timeline-font-scale, 1)), 16px);
+    transform: scaleX(var(--timeline-zoom-inverse, 1));
+    transform-origin: center;
 }
 
 .period-icon-wrapper {
@@ -411,8 +415,6 @@ h1 {
     border-radius: 10px;
     overflow: hidden;
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
-    transform: scaleX(var(--timeline-zoom-inverse, 1));
-    transform-origin: center;
 }
 
 :root[data-theme="light"] .period-icon-wrapper {


### PR DESCRIPTION
## Summary
- center the historical period content within each timeline band
- add inverse zoom scaling so the period descriptions keep a consistent size
- simplify the icon wrapper transform now that centering handles the layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6d8c6d2088326943c4e32100632ce