### PR TITLE
Stabilize timeline year labels across zoom levels

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -373,7 +373,8 @@ h1 {
     position: absolute;
     bottom: -46px;
     left: 50%;
-    transform: translateX(-50%);
+    transform: translateX(-50%) scaleX(var(--timeline-zoom-inverse, 1));
+    transform-origin: center bottom;
     font-size: clamp(0.75rem, 0.7rem + 0.18vw, 1.05rem);
     color: var(--tick-label-color);
     white-space: nowrap;

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -136,7 +136,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const tickConfigs = [
         {
-            maxZoom: 0.4,
+            maxZoom: 0.35,
             step: 100,
             majorStep: 100,
             formatLabel: (year) => {
@@ -151,22 +151,22 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         },
         {
-            maxZoom: 0.65,
+            maxZoom: 0.55,
             step: 50,
             majorStep: 50
         },
         {
-            maxZoom: 1,
-            step: 25,
-            majorStep: 50
+            maxZoom: 0.9,
+            step: 20,
+            majorStep: 40
         },
         {
-            maxZoom: 1.6,
+            maxZoom: 1.5,
             step: 10,
             majorStep: 20
         },
         {
-            maxZoom: 2.4,
+            maxZoom: 2.3,
             step: 5,
             majorStep: 10
         },


### PR DESCRIPTION
## Summary
- prevent year tick labels from stretching when zooming by counter-scaling the text
- increase the density of year labels by tightening zoom thresholds and step values

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e6df128e20832680e8078a7e81d556