### PR TITLE
Reintroduce key phases of liberal Italy

### DIFF
--- a/assets/js/timeline-data.js
+++ b/assets/js/timeline-data.js
@@ -37,6 +37,33 @@ window.TIMELINE_DATA = {
             iconAlt: "Bandiera del Regno d'Italia"
         },
         {
+            name: "Destra storica",
+            start: 1861,
+            end: 1876,
+            color: "rgba(129,212,250,0.32)",
+            lane: 0,
+            icon: "https://upload.wikimedia.org/wikipedia/commons/4/45/Camillo_benso_count_of_Cavour.jpg",
+            iconAlt: "Camillo Benso, conte di Cavour"
+        },
+        {
+            name: "Sinistra storica",
+            start: 1876,
+            end: 1896,
+            color: "rgba(129,212,250,0.32)",
+            lane: 1,
+            icon: "https://upload.wikimedia.org/wikipedia/commons/3/30/Agostino_Depretis_%28cropped%29.jpg",
+            iconAlt: "Agostino Depretis"
+        },
+        {
+            name: "Età giolittiana",
+            start: 1903,
+            end: 1914,
+            color: "rgba(255,214,126,0.32)",
+            lane: 3,
+            icon: "https://upload.wikimedia.org/wikipedia/commons/f/f8/Giovanni_Giolitti_1920.jpg",
+            iconAlt: "Giovanni Giolitti"
+        },
+        {
             name: "Crisi liberale e riforme",
             start: 1912,
             end: 1919,


### PR DESCRIPTION
## Summary
- add period blocks for Destra storica, Sinistra storica, and Età giolittiana to restore key liberal-era phases
- provide representative portraits and colors for each newly reintroduced phase

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6dfad86608326abae23d8342b37d3