### PR TITLE
Amplia la minimappa della timeline

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -553,24 +553,25 @@ h1 {
     bottom: 26px;
     left: 50%;
     transform: translateX(-50%);
-    width: min(90vw, 960px);
-    height: 104px;
-    border-radius: 32px;
+    width: min(92vw, 1080px);
+    height: 156px;
+    border-radius: 36px;
     background: var(--minimap-bg);
     border: 1px solid var(--minimap-border);
-    padding: 16px 24px 24px;
+    padding: 22px 28px 30px;
     display: flex;
     align-items: stretch;
     z-index: 3;
-    box-shadow: 0 24px 60px rgba(0,0,0,0.45);
+    box-shadow: 0 28px 70px rgba(0,0,0,0.46);
 }
 
 .minimap-track {
     position: relative;
     flex: 1;
     height: 100%;
-    border-radius: 18px;
+    border-radius: 22px;
     background: var(--minimap-track-bg);
+    padding: 10px 0 18px;
     overflow: hidden;
 }
 
@@ -587,8 +588,8 @@ h1 {
 .minimap-period {
     position: absolute;
     top: 50%;
-    height: 50%;
-    border-radius: 12px;
+    height: 64%;
+    border-radius: 16px;
     transform: translateY(-50%);
     opacity: 0.55;
     z-index: 1;
@@ -596,10 +597,10 @@ h1 {
 
 .minimap-period-label {
     position: absolute;
-    bottom: 10px;
+    bottom: 14px;
     left: 0;
-    padding-left: 8px;
-    font-size: 0.65rem;
+    padding-left: 10px;
+    font-size: 0.72rem;
     font-weight: 600;
     color: var(--minimap-label-color);
     white-space: nowrap;
@@ -607,7 +608,7 @@ h1 {
     text-overflow: ellipsis;
     pointer-events: none;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.05em;
     text-shadow: 0 2px 10px var(--minimap-label-shadow);
     z-index: 2;
 }
@@ -616,7 +617,7 @@ h1 {
     position: absolute;
     top: 0;
     bottom: 0;
-    border-radius: 16px;
+    border-radius: 20px;
     border: 2px solid var(--minimap-viewport-border);
     background: var(--minimap-viewport-bg);
     cursor: grab;


### PR DESCRIPTION
## Summary
- amplia le dimensioni della minimappa in fondo alla pagina per offrire una visualizzazione più generosa
- aggiorna traccia, etichette e viewport della minimappa per mantenere proporzioni e leggibilità con il nuovo layout

## Testing
- non eseguito (non applicabile)


------
https://chatgpt.com/codex/tasks/task_e_68e6e2555af4832689eb0314fce47bf5