### PR TITLE
Increase tick density across zoom levels

### DIFF
--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -137,7 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const tickConfigs = [
         {
             maxZoom: 0.35,
-            step: 100,
+            step: 50,
             majorStep: 100,
             formatLabel: (year) => {
                 const century = Math.floor((year - 1) / 100) + 1;
@@ -152,22 +152,22 @@ document.addEventListener('DOMContentLoaded', () => {
         },
         {
             maxZoom: 0.55,
-            step: 50,
+            step: 25,
             majorStep: 50
         },
         {
             maxZoom: 0.9,
-            step: 20,
-            majorStep: 40
-        },
-        {
-            maxZoom: 1.5,
             step: 10,
             majorStep: 20
         },
         {
-            maxZoom: 2.3,
+            maxZoom: 1.5,
             step: 5,
+            majorStep: 10
+        },
+        {
+            maxZoom: 2.3,
+            step: 2,
             majorStep: 10
         },
         {


### PR DESCRIPTION
## Summary
- increase the number of timeline tick labels shown at each zoom level
- adjust tick configuration thresholds to surface years more frequently as users zoom in

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6e41432908326b5a56246dc5e3ee7