### PR TITLE
Extend timeline to 1800-2025

### DIFF
--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -114,12 +114,17 @@ document.addEventListener('DOMContentLoaded', () => {
         return y + (m - 1) / 12 + (d - 1) / 365;
     };
 
+    const TIMELINE_MIN_YEAR = 1800;
+    const TIMELINE_MAX_YEAR = 2025;
+
     const allDates = [
         ...data.periods.flatMap((period) => [period.start, period.end]),
         ...data.events.map((event) => parseDate(event.date))
     ];
-    const minYear = Math.floor(Math.min(...allDates));
-    const maxYear = Math.ceil(Math.max(...allDates));
+    const computedMinYear = Math.floor(Math.min(...allDates));
+    const computedMaxYear = Math.ceil(Math.max(...allDates));
+    const minYear = Math.min(computedMinYear, TIMELINE_MIN_YEAR);
+    const maxYear = Math.max(computedMaxYear, TIMELINE_MAX_YEAR);
     const totalYears = maxYear - minYear;
     const basePixelsPerYear = 110;
     const baseWidth = totalYears * basePixelsPerYear;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Timeline Interattiva • Storia d'Italia 1815-1948</title>
+    <title>Timeline Interattiva • Storia d'Italia 1800-2025</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/timeline.css">
 </head>
@@ -11,7 +11,7 @@
     <div class="bg-particles"></div>
 
     <header>
-        <h1>Storia d'Italia • 1815-1948</h1>
+        <h1>Storia d'Italia • 1800-2025</h1>
         <div class="controls">
             <div class="zoom-controls">
                 <button class="zoom-btn" data-action="out" aria-label="Riduci zoom">−</button>
@@ -50,7 +50,7 @@
     </div>
 
     <div class="year-indicator">
-        <div class="year-badge">1815</div>
+        <div class="year-badge">1800</div>
     </div>
 
     <script src="assets/js/timeline-data.js"></script>


### PR DESCRIPTION
## Summary
- extend the rendered timeline range to include the years 1800 through 2025
- update the page title, header, and year indicator to reflect the expanded range

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6e442c6dc8326b4cb79ac9047154c