### PR TITLE
Add Regno d'Italia period to timeline

### DIFF
--- a/assets/js/timeline-data.js
+++ b/assets/js/timeline-data.js
@@ -51,6 +51,16 @@ window.TIMELINE_DATA = {
             description: "Il nuovo Stato unitario uniforma istituzioni, burocrazia e diritto con leggi centrali e grandi codificazioni civili e penali."
         },
         {
+            name: "Regno d'Italia",
+            start: 1861,
+            end: 1946,
+            color: "rgba(102,187,106,0.35)",
+            lane: 6,
+            icon: "https://upload.wikimedia.org/wikipedia/commons/8/87/Regno_d%27Italia_stemma.png",
+            iconAlt: "Stemma del Regno d'Italia",
+            description: "Monarchia costituzionale dei Savoia: dura complessivamente 85 anni, dal 17 marzo 1861 al referendum istituzionale del 2 giugno 1946."
+        },
+        {
             name: "Destra storica",
             start: 1861,
             end: 1876,

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
                 <span><i style="background: rgba(121,134,203,0.4);"></i> Fermento costituzionale e rivoluzioni</span>
                 <span><i style="background: rgba(244,143,177,0.6);"></i> Carte costituzionali e Risorgimento</span>
                 <span><i style="background: rgba(129,212,250,0.6);"></i> Unificazione e codici post-unitari</span>
+                <span><i style="background: rgba(102,187,106,0.6);"></i> Regno d'Italia (monarchia sabauda)</span>
                 <span><i style="background: rgba(255,214,126,0.6);"></i> Crisi liberale e riforme</span>
                 <span><i style="background: rgba(255,138,128,0.6);"></i> Regime fascista e legislazione autoritaria</span>
                 <span><i style="background: rgba(186,104,200,0.6);"></i> Transizione repubblicana e Costituzione</span>


### PR DESCRIPTION
## Summary
- add a dedicated period for the Regno d'Italia highlighting its full duration from 1861 to 1946
- extend the legend to explain the new color associated with the monarchy period

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e6e63421708326aae505356f53d454