### PR TITLE
Allinea i marker degli eventi alla linea temporale

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -502,6 +502,7 @@ h1 {
     cursor: pointer;
     transition: transform 0.2s ease;
     z-index: 2;
+    --event-card-offset: 0px;
 }
 
 .event-marker {
@@ -538,7 +539,7 @@ h1 {
 .event-card {
     position: absolute;
     left: 50%;
-    bottom: calc(100% + 18px);
+    bottom: calc(100% + 18px + var(--event-card-offset, 0px));
     transform: translate(-50%, 12px) scaleX(var(--timeline-zoom-inverse, 1));
     transform-origin: bottom;
     min-width: 260px;

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -135,7 +135,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const laneOffsets = [-110, 90, -180, 200];
     const minimapLaneBase = 35;
     const minimapLaneSpacing = 15;
-    const levelOffsets = { 1: 0, 2: -110, 3: -200 };
+    const levelCardOffsets = { 1: 0, 2: 110, 3: 200 };
 
     const tickElements = [];
 
@@ -316,8 +316,9 @@ document.addEventListener('DOMContentLoaded', () => {
             el.dataset.level = event.level;
             const position = ((parseDate(event.date) - minYear) / totalYears) * baseWidth;
             el.style.left = `${position}px`;
-            const levelOffset = levelOffsets[event.level] ?? 0;
-            el.style.top = `calc(50% + ${levelOffset}px)`;
+            el.style.top = '50%';
+            const cardOffset = levelCardOffsets[event.level] ?? 0;
+            el.style.setProperty('--event-card-offset', `${cardOffset}px`);
 
             const marker = document.createElement('div');
             marker.className = 'event-marker';


### PR DESCRIPTION
## Summary
- mantieni i marker degli eventi storici allineati con la linea centrale degli anni
- applica offset verticali solo alle card informative tramite variabili CSS dedicate

## Testing
- not run (non disponibile)


------
https://chatgpt.com/codex/tasks/task_e_68e6e6ce0ae883269c6f35a93377ab8f