### PR TITLE
Fix minimap period labels overlapping

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -653,7 +653,8 @@ h1 {
 
 .minimap-period-label {
     position: absolute;
-    bottom: 14px;
+    --label-row: 0;
+    bottom: calc(14px + var(--label-row) * 18px);
     left: 0;
     padding-left: 10px;
     font-size: 0.72rem;

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -187,6 +187,38 @@ document.addEventListener('DOMContentLoaded', () => {
         return clean.length > 22 ? `${clean.slice(0, 22).trim()}…` : clean;
     };
 
+    const layoutMinimapLabels = () => {
+        if (!minimap) return;
+
+        const labels = Array.from(minimap.querySelectorAll('.minimap-period-label'));
+        if (!labels.length) return;
+
+        labels.forEach((label) => {
+            label.style.setProperty('--label-row', '0');
+        });
+
+        const labelData = labels
+            .map((label) => {
+                const rect = label.getBoundingClientRect();
+                return { label, left: rect.left, right: rect.right };
+            })
+            .sort((a, b) => a.left - b.left);
+
+        const rowEndings = [];
+        const gap = 8;
+
+        labelData.forEach(({ label, left, right }) => {
+            let rowIndex = rowEndings.findIndex((end) => left >= end);
+            if (rowIndex === -1) {
+                rowIndex = rowEndings.length;
+                rowEndings.push(right + gap);
+            } else {
+                rowEndings[rowIndex] = right + gap;
+            }
+            label.style.setProperty('--label-row', String(rowIndex));
+        });
+    };
+
     const addTicks = () => {
         for (let year = minYear; year <= maxYear; year++) {
             const tick = document.createElement('div');
@@ -307,6 +339,8 @@ document.addEventListener('DOMContentLoaded', () => {
             miniLabel.style.width = `${(width / baseWidth) * 100}%`;
             minimap.appendChild(miniLabel);
         });
+
+        requestAnimationFrame(layoutMinimapLabels);
     };
 
     const addEvents = () => {
@@ -546,6 +580,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     window.addEventListener('resize', () => {
         updateTransforms();
+        requestAnimationFrame(layoutMinimapLabels);
     });
 
     const init = () => {


### PR DESCRIPTION
## Summary
- introduce a layout pass that assigns stacked rows to minimap period labels when they would overlap
- expose a CSS custom property to offset labels vertically and reuse it during the layout pass
- recompute the label layout after rendering periods and when the viewport is resized

## Testing
- Manually opened index.html in a browser

------
https://chatgpt.com/codex/tasks/task_e_68e6e793923883268763441e5eb97ed0