### PR TITLE
Aggiorna icona età umbertina

### DIFF
--- a/assets/js/timeline-data.js
+++ b/assets/js/timeline-data.js
@@ -86,8 +86,8 @@ window.TIMELINE_DATA = {
             end: 1900,
             color: "rgba(129,212,250,0.22)",
             lane: 4,
-            icon: "https://upload.wikimedia.org/wikipedia/commons/7/73/Umberto_I_di_Savoia%2C_re_d%27Italia.jpg",
-            iconAlt: "Umberto I di Savoia",
+            icon: "https://upload.wikimedia.org/wikipedia/commons/5/57/Lesser_coat_of_arms_of_the_Kingdom_of_Italy_%281890%29.svg",
+            iconAlt: "Stemma minore del Regno d'Italia nel 1890",
             description: "Il regno di Umberto I è segnato da industrializzazione, tensioni sociali e dalla stretta autoritaria dopo moti e attentati."
         },
         {


### PR DESCRIPTION
## Summary
- aggiornata l'immagine della voce "Età umbertina" usando lo stemma minore del Regno d'Italia del 1890
- migliorata la descrizione alternativa per riflettere il nuovo stemma

## Testing
- non sono stati eseguiti test (modifica solo a dati/statici)


------
https://chatgpt.com/codex/tasks/task_e_68e6e81439ec8326a20b53d33f54c24d