### PR TITLE
Add Italian Republic era to interactive timeline

### DIFF
--- a/assets/js/timeline-data.js
+++ b/assets/js/timeline-data.js
@@ -145,6 +145,16 @@ window.TIMELINE_DATA = {
             icon: "https://upload.wikimedia.org/wikipedia/commons/0/00/Emblem_of_Italy.svg",
             iconAlt: "Emblema della Repubblica Italiana",
             description: "L'Assemblea Costituente elabora la Costituzione repubblicana e ricostruisce istituzioni democratiche avviando la stagione delle riforme."
+        },
+        {
+            name: "Repubblica Italiana",
+            start: 1946,
+            end: 2025,
+            color: "rgba(76,175,80,0.4)",
+            lane: 3,
+            icon: "https://upload.wikimedia.org/wikipedia/commons/0/00/Emblem_of_Italy.svg",
+            iconAlt: "Emblema della Repubblica Italiana",
+            description: "Dal referendum del 2 giugno 1946 la Repubblica italiana consolida le istituzioni democratiche, sviluppa il welfare e partecipa alla costruzione europea fino all'età contemporanea."
         }
     ],
     events: [

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
                 <span><i style="background: rgba(255,214,126,0.6);"></i> Crisi liberale e riforme</span>
                 <span><i style="background: rgba(255,138,128,0.6);"></i> Regime fascista e legislazione autoritaria</span>
                 <span><i style="background: rgba(186,104,200,0.6);"></i> Transizione repubblicana e Costituzione</span>
+                <span><i style="background: rgba(76,175,80,0.6);"></i> Repubblica Italiana</span>
             </div>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- add a "Repubblica Italiana" period covering 1946 to the present in the timeline data with descriptive copy and styling
- extend the legend to show the new Italian Republic color category

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e6e71a7f7c8326bd19b43db115b7a2