### PR TITLE
Add Second World War period to timeline

### DIFF
--- a/assets/js/timeline-data.js
+++ b/assets/js/timeline-data.js
@@ -129,6 +129,16 @@ window.TIMELINE_DATA = {
             description: "Le leggi fascistissime smantellano libertà parlamentari e pluralismo, imponendo il partito unico e il controllo capillare della società."
         },
         {
+            name: "Seconda guerra mondiale",
+            start: 1939,
+            end: 1945,
+            color: "rgba(255,112,67,0.55)",
+            lane: 4,
+            icon: "https://upload.wikimedia.org/wikipedia/commons/7/7e/WWII_Military_Collage.png",
+            iconAlt: "Montaggio di scene militari della Seconda guerra mondiale",
+            description: "Il conflitto globale travolge l'Italia tra campagne militari fallimentari, occupazione straniera, Resistenza e profonde lacerazioni civili."
+        },
+        {
             name: "Transizione alla democrazia",
             start: 1943,
             end: 1946,

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
                 <span><i style="background: rgba(102,187,106,0.6);"></i> Regno d'Italia (monarchia sabauda)</span>
                 <span><i style="background: rgba(255,214,126,0.6);"></i> Crisi liberale e riforme</span>
                 <span><i style="background: rgba(255,138,128,0.6);"></i> Regime fascista e legislazione autoritaria</span>
+                <span><i style="background: rgba(255,112,67,0.55);"></i> Seconda guerra mondiale</span>
                 <span><i style="background: rgba(186,104,200,0.6);"></i> Transizione repubblicana e Costituzione</span>
                 <span><i style="background: rgba(67,160,71,0.6);"></i> Repubblica Italiana (dal 1946)</span>
             </div>


### PR DESCRIPTION
## Summary
- add a dedicated Second World War period to the timeline dataset with imagery and description
- extend the legend to include the new Second World War color coding

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6ebbc1f98832685ddae359194d0ea