### PR TITLE
Show start year on timeline periods and include icons in popups

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -18,6 +18,8 @@
     --tick-label-color: rgba(255, 255, 255, 0.75);
     --period-text-color: #ffffff;
     --period-shadow: rgba(0, 0, 0, 0.35);
+    --period-start-bg: rgba(8, 11, 36, 0.45);
+    --period-start-border: rgba(255, 255, 255, 0.32);
     --event-marker-gradient: linear-gradient(135deg, #ffffff, #c5cae9);
     --event-marker-outline: rgba(255, 255, 255, 0.4);
     --event-marker-glow: rgba(255, 255, 255, 0.75);
@@ -65,6 +67,8 @@
     --tick-label-color: rgba(26, 27, 46, 0.7);
     --period-text-color: #1a1b2e;
     --period-shadow: rgba(122, 130, 180, 0.25);
+    --period-start-bg: rgba(92, 107, 192, 0.18);
+    --period-start-border: rgba(92, 107, 192, 0.28);
     --event-marker-gradient: linear-gradient(135deg, #5c6bc0, #9fa8da);
     --event-marker-outline: rgba(92, 107, 192, 0.35);
     --event-marker-glow: rgba(92, 107, 192, 0.45);
@@ -407,6 +411,22 @@ h1 {
     transform-origin: center;
 }
 
+.period-start-year {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: clamp(0.7rem, 0.68rem + 0.24vw, 0.95rem);
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--period-text-color);
+    background: var(--period-start-bg);
+    box-shadow: inset 0 0 0 1px var(--period-start-border);
+    white-space: nowrap;
+}
+
 .period-icon-wrapper {
     flex: 0 0 auto;
     width: 34px;
@@ -488,6 +508,24 @@ h1 {
     font-weight: 700;
     color: var(--event-card-title);
     margin-bottom: 8px;
+}
+
+.period-card-media {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 12px;
+}
+
+.period-card-image {
+    max-width: clamp(64px, 8vw, 120px);
+    max-height: 100px;
+    object-fit: contain;
+    display: block;
+    filter: drop-shadow(0 8px 20px rgba(0, 0, 0, 0.35));
+}
+
+:root[data-theme="light"] .period-card-image {
+    filter: drop-shadow(0 6px 18px rgba(92, 107, 192, 0.28));
 }
 
 .period-card-description {

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -286,6 +286,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 content.appendChild(iconWrapper);
             }
 
+            const startYear = document.createElement('span');
+            startYear.className = 'period-start-year';
+            startYear.textContent = `${period.start}`;
+            content.appendChild(startYear);
+
             const label = document.createElement('span');
             label.className = 'period-name';
             label.textContent = period.name;
@@ -295,6 +300,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const card = document.createElement('div');
             card.className = 'period-card';
+
+            if (period.icon) {
+                const cardMedia = document.createElement('div');
+                cardMedia.className = 'period-card-media';
+
+                const cardImage = document.createElement('img');
+                cardImage.className = 'period-card-image';
+                cardImage.src = period.icon;
+                cardImage.alt = period.iconAlt ?? period.name;
+                cardImage.loading = 'lazy';
+                cardImage.decoding = 'async';
+
+                cardMedia.appendChild(cardImage);
+                card.appendChild(cardMedia);
+            }
 
             const range = document.createElement('div');
             range.className = 'period-range';


### PR DESCRIPTION
## Summary
- show the starting year on every period label so it stays visible regardless of zoom
- display the period icon inside the hover popup with theme-aware styling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e747ba66648326a0880062bcea92d3