### PR TITLE
Fix zoom controls layout

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -265,6 +265,7 @@ h1 {
     border: 1px solid var(--control-border);
     overflow: hidden;
     box-shadow: 0 12px 30px rgba(10, 20, 60, 0.25);
+    flex-shrink: 0;
 }
 
 .zoom-btn {
@@ -289,6 +290,8 @@ h1 {
     font-weight: 600;
     border-left: 1px solid var(--control-border);
     border-right: 1px solid var(--control-border);
+    text-align: center;
+    white-space: nowrap;
 }
 
 .legend {


### PR DESCRIPTION
## Summary
- prevent the zoom controls container from shrinking so the buttons remain fully visible
- keep the zoom percentage centered and on a single line within the control

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e75448c2308326bcecf1ca9beed0d0