### PR TITLE
Show period start and end years in timeline bands

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -392,7 +392,7 @@ h1 {
     transform: translateY(-50%);
     border-radius: 14px;
     padding: 8px clamp(16px, 18px + 0.4vw, 28px);
-    display: inline-flex;
+    display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
@@ -407,14 +407,27 @@ h1 {
 }
 
 .period-content {
-    display: inline-flex;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
     gap: clamp(8px, calc(10px * var(--timeline-font-scale, 1)), 16px);
+    width: 100%;
     transform: scaleX(var(--timeline-zoom-inverse, 1));
     transform-origin: center;
 }
 
-.period-start-year {
+.period-main {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: clamp(6px, calc(8px * var(--timeline-font-scale, 1)), 14px);
+    justify-self: center;
+    min-width: 0;
+    text-align: center;
+}
+
+.period-start-year,
+.period-end-year {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -428,6 +441,15 @@ h1 {
     background: var(--period-start-bg);
     box-shadow: inset 0 0 0 1px var(--period-start-border);
     white-space: nowrap;
+}
+
+.period-start-year {
+    justify-self: start;
+}
+
+.period-end-year {
+    justify-self: end;
+    text-align: right;
 }
 
 .period-icon-wrapper {
@@ -455,6 +477,7 @@ h1 {
 
 .period-name {
     white-space: nowrap;
+    min-width: 0;
 }
 
 .period:hover {

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -271,6 +271,13 @@ document.addEventListener('DOMContentLoaded', () => {
             const content = document.createElement('div');
             content.className = 'period-content';
 
+            const startYear = document.createElement('span');
+            startYear.className = 'period-start-year';
+            startYear.textContent = `${period.start}`;
+
+            const main = document.createElement('div');
+            main.className = 'period-main';
+
             if (period.icon) {
                 const iconWrapper = document.createElement('div');
                 iconWrapper.className = 'period-icon-wrapper';
@@ -283,18 +290,21 @@ document.addEventListener('DOMContentLoaded', () => {
                 icon.decoding = 'async';
 
                 iconWrapper.appendChild(icon);
-                content.appendChild(iconWrapper);
+                main.appendChild(iconWrapper);
             }
-
-            const startYear = document.createElement('span');
-            startYear.className = 'period-start-year';
-            startYear.textContent = `${period.start}`;
-            content.appendChild(startYear);
 
             const label = document.createElement('span');
             label.className = 'period-name';
             label.textContent = period.name;
-            content.appendChild(label);
+            main.appendChild(label);
+
+            const endYear = document.createElement('span');
+            endYear.className = 'period-end-year';
+            endYear.textContent = `${period.end}`;
+
+            content.appendChild(startYear);
+            content.appendChild(main);
+            content.appendChild(endYear);
 
             el.appendChild(content);
 


### PR DESCRIPTION
## Summary
- reposition the period start year to the left edge of each timeline band and add the end year on the right edge
- restructure the period markup and styling so the title (and optional icon) remain centered between the new year badges

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7566f30b08326834776b0323043a9