### PR TITLE
Allinea le etichette degli anni limite sulla timeline

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -387,6 +387,21 @@ h1 {
     white-space: nowrap;
 }
 
+.timeline-tick-label-start {
+    left: 0;
+    transform: scaleX(var(--timeline-zoom-inverse, 1));
+    transform-origin: left bottom;
+    text-align: left;
+}
+
+.timeline-tick-label-end {
+    left: auto;
+    right: 0;
+    transform: scaleX(var(--timeline-zoom-inverse, 1));
+    transform-origin: right bottom;
+    text-align: right;
+}
+
 .period {
     position: absolute;
     transform: translateY(-50%);

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -238,6 +238,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const label = document.createElement('div');
             label.className = 'timeline-tick-label';
+
+            if (year === minYear) {
+                tick.classList.add('timeline-tick-start');
+                label.classList.add('timeline-tick-label-start');
+            } else if (year === maxYear) {
+                tick.classList.add('timeline-tick-end');
+                label.classList.add('timeline-tick-label-end');
+            }
+
             tick.appendChild(label);
             inner.appendChild(tick);
 


### PR DESCRIPTION
## Summary
- aggiunge classi dedicate ai tick iniziale e finale per mantenerli allineati sulla linea della timeline
- aggiorna gli stili delle etichette dei limiti per allinearle e scalare come i tick intermedi

## Testing
- non eseguito (modifiche front-end)

------
https://chatgpt.com/codex/tasks/task_e_68e76468e91c83268026ebe26c13de8a