### PR TITLE
Enable pinch zoom on touch devices

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -327,6 +327,7 @@ h1 {
     overflow: hidden;
     cursor: grab;
     z-index: 1;
+    touch-action: none;
 }
 
 .timeline-shell.dragging {


### PR DESCRIPTION
## Summary
- track multiple active pointers on the timeline shell to support pinch gestures for zooming
- gracefully transition between pinch zooming and single-finger panning as touch contacts change
- disable the browser's default touch handling on the timeline container to allow custom gestures

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e792d0aed88326a17a715220e1c334