### PR TITLE
Adjust period year badges on the timeline

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -422,9 +422,9 @@ h1 {
 }
 
 .period-content {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto;
+    display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: clamp(8px, calc(10px * var(--timeline-font-scale, 1)), 16px);
     width: 100%;
     transform: scaleX(var(--timeline-zoom-inverse, 1));
@@ -441,14 +441,17 @@ h1 {
     text-align: center;
 }
 
-.period-start-year,
-.period-end-year {
+.period-year-marker {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%) scaleX(var(--timeline-zoom-inverse, 1));
+    transform-origin: center;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     padding: 4px 10px;
     border-radius: 999px;
-    font-size: clamp(0.7rem, 0.68rem + 0.24vw, 0.95rem);
+    font-size: clamp(0.6rem, 0.58rem + 0.18vw, 0.85rem);
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -456,16 +459,12 @@ h1 {
     background: var(--period-start-bg);
     box-shadow: inset 0 0 0 1px var(--period-start-border);
     white-space: nowrap;
+    pointer-events: none;
+    z-index: 2;
+    line-height: 1.1;
 }
 
-.period-start-year {
-    justify-self: start;
-}
 
-.period-end-year {
-    justify-self: end;
-    text-align: right;
-}
 
 .period-icon-wrapper {
     flex: 0 0 auto;

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -290,10 +290,6 @@ document.addEventListener('DOMContentLoaded', () => {
             const content = document.createElement('div');
             content.className = 'period-content';
 
-            const startYear = document.createElement('span');
-            startYear.className = 'period-start-year';
-            startYear.textContent = `${period.start}`;
-
             const main = document.createElement('div');
             main.className = 'period-main';
 
@@ -317,13 +313,7 @@ document.addEventListener('DOMContentLoaded', () => {
             label.textContent = period.name;
             main.appendChild(label);
 
-            const endYear = document.createElement('span');
-            endYear.className = 'period-end-year';
-            endYear.textContent = `${period.end}`;
-
-            content.appendChild(startYear);
             content.appendChild(main);
-            content.appendChild(endYear);
 
             el.appendChild(content);
 
@@ -371,6 +361,20 @@ document.addEventListener('DOMContentLoaded', () => {
             el.style.top = `calc(50% + ${laneOffset}px)`;
             el.style.background = period.color;
             inner.appendChild(el);
+
+            const createYearMarker = (year, variant) => {
+                const marker = document.createElement('div');
+                marker.className = `period-year-marker period-year-marker--${variant}`;
+                marker.textContent = `${year}`;
+                const position = ((year - minYear) / totalYears) * baseWidth;
+                marker.style.left = `${position}px`;
+                mainLine.appendChild(marker);
+            };
+
+            createYearMarker(period.start, 'start');
+            if (period.end !== period.start) {
+                createYearMarker(period.end, 'end');
+            }
 
             const mini = document.createElement('div');
             mini.className = 'minimap-period';


### PR DESCRIPTION
## Summary
- render start and end years as dedicated markers positioned on the main timeline line
- simplify the period content layout now that year badges are removed from the period cards

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e76c7163f48326a65bb80a1be4fcf2