### PR TITLE
Allow zooming out to 5 percent

### DIFF
--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const state = {
         zoom: 1,
-        minZoom: 0.2,
+        minZoom: 0.05,
         maxZoom: 4,
         translate: 0,
         isPointerDown: false,


### PR DESCRIPTION
## Summary
- allow the timeline view to zoom out as far as 5% by lowering the minimum zoom level

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7977e69008326a98ecf7801dc01a2