### PR TITLE
Remove overlapping timeline tick labels

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -383,43 +383,6 @@ h1 {
     background: var(--tick-major-color);
 }
 
-.timeline-tick-label {
-    position: absolute;
-    bottom: -46px;
-    left: 50%;
-    transform: translateX(-50%) scaleX(var(--timeline-zoom-inverse, 1));
-    transform-origin: center bottom;
-    font-size: clamp(0.75rem, 0.7rem + 0.18vw, 1.05rem);
-    color: var(--tick-label-color);
-    white-space: nowrap;
-    background: var(--tick-label-bg);
-    padding: 6px 12px;
-    border-radius: 999px;
-    border: 1px solid var(--tick-label-border);
-    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
-    letter-spacing: 0.08em;
-    font-weight: 600;
-}
-
-:root[data-theme="light"] .timeline-tick-label {
-    box-shadow: 0 10px 20px rgba(92, 107, 192, 0.18);
-}
-
-.timeline-tick-label-start {
-    left: 0;
-    transform: scaleX(var(--timeline-zoom-inverse, 1));
-    transform-origin: left bottom;
-    text-align: left;
-}
-
-.timeline-tick-label-end {
-    left: auto;
-    right: 0;
-    transform: scaleX(var(--timeline-zoom-inverse, 1));
-    transform-origin: right bottom;
-    text-align: right;
-}
-
 .period {
     position: absolute;
     transform: translateY(-50%);

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -246,21 +246,15 @@ document.addEventListener('DOMContentLoaded', () => {
             const position = ((year - minYear) / totalYears) * baseWidth;
             tick.style.left = `${position}px`;
 
-            const label = document.createElement('div');
-            label.className = 'timeline-tick-label';
-
             if (year === minYear) {
                 tick.classList.add('timeline-tick-start');
-                label.classList.add('timeline-tick-label-start');
             } else if (year === maxYear) {
                 tick.classList.add('timeline-tick-end');
-                label.classList.add('timeline-tick-label-end');
             }
 
-            tick.appendChild(label);
             inner.appendChild(tick);
 
-            tickElements.push({ tick, label, year });
+            tickElements.push({ tick, year });
         }
     };
 
@@ -270,7 +264,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const config = tickConfigs.find((entry) => state.zoom < entry.maxZoom) || tickConfigs[tickConfigs.length - 1];
         const anchor = Math.ceil(minYear / config.step) * config.step;
 
-        tickElements.forEach(({ tick, label, year }) => {
+        tickElements.forEach(({ tick, year }) => {
             const isFirstYear = year === minYear;
             const isLastYear = year === maxYear;
             const isAligned = year >= anchor && ((year - anchor) % config.step === 0);
@@ -284,10 +278,6 @@ document.addEventListener('DOMContentLoaded', () => {
             const majorStep = config.majorStep ?? config.step;
             const isMajor = year % majorStep === 0;
             tick.classList.toggle('major', isMajor);
-            const formatter = (isFirstYear || isLastYear)
-                ? ((value) => value)
-                : (config.formatLabel ?? ((value) => value));
-            label.textContent = `${formatter(year)}`;
         });
     };
 


### PR DESCRIPTION
## Summary
- remove the timeline tick label elements so only the markers remain visible
- drop the related CSS styles that created overlapping pill-shaped year badges

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e7a7e652648326b07a66b19ca59f69