### PR TITLE
Restore timeline labels and add clickable period markers

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -385,24 +385,25 @@ h1 {
 
 .timeline-tick-label {
     position: absolute;
-    bottom: -46px;
+    bottom: -42px;
     left: 50%;
     transform: translateX(-50%) scaleX(var(--timeline-zoom-inverse, 1));
     transform-origin: center bottom;
-    font-size: clamp(0.75rem, 0.7rem + 0.18vw, 1.05rem);
+    font-size: clamp(0.65rem, 0.6rem + 0.18vw, 0.95rem);
     color: var(--tick-label-color);
     white-space: nowrap;
     background: var(--tick-label-bg);
-    padding: 6px 12px;
-    border-radius: 999px;
+    padding: 5px 10px;
+    border-radius: 12px;
     border: 1px solid var(--tick-label-border);
-    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
     letter-spacing: 0.08em;
     font-weight: 600;
+    text-transform: uppercase;
 }
 
 :root[data-theme="light"] .timeline-tick-label {
-    box-shadow: 0 10px 20px rgba(92, 107, 192, 0.18);
+    box-shadow: 0 10px 18px rgba(92, 107, 192, 0.18);
 }
 
 .timeline-tick-label-start {
@@ -464,22 +465,71 @@ h1 {
     top: 50%;
     transform: translate(-50%, -50%) scaleX(var(--timeline-zoom-inverse, 1));
     transform-origin: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #64b5f6, #1e88e5);
+    box-shadow: 0 0 16px rgba(33, 150, 243, 0.4), 0 0 0 2px rgba(5, 7, 25, 0.7);
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    pointer-events: auto;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 4px 10px;
-    border-radius: 999px;
-    font-size: clamp(0.6rem, 0.58rem + 0.18vw, 0.85rem);
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--period-text-color);
-    background: var(--period-start-bg);
-    box-shadow: inset 0 0 0 1px var(--period-start-border);
-    white-space: nowrap;
-    pointer-events: none;
-    z-index: 2;
-    line-height: 1.1;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    z-index: 3;
+    appearance: none;
+    -webkit-appearance: none;
+}
+
+.period-year-marker--end {
+    background: linear-gradient(135deg, #42a5f5, #1565c0);
+}
+
+.period-year-marker::after {
+    content: '';
+    position: absolute;
+    inset: -8px;
+    border-radius: 50%;
+    border: 1px solid rgba(33, 150, 243, 0.35);
+    opacity: 0;
+    transform: scale(0.6) scaleX(var(--timeline-zoom-inverse, 1));
+    transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.period-year-marker:hover,
+.period-year-marker:focus-visible,
+.period-year-marker.is-active {
+    box-shadow: 0 0 18px rgba(100, 181, 246, 0.55), 0 0 0 2px rgba(5, 7, 25, 0.6);
+    transform: translate(-50%, -50%) scaleX(var(--timeline-zoom-inverse, 1)) scale(1.08);
+}
+
+.period-year-marker:hover::after,
+.period-year-marker:focus-visible::after,
+.period-year-marker.is-active::after {
+    opacity: 1;
+    transform: scale(1) scaleX(var(--timeline-zoom-inverse, 1));
+}
+
+.period-year-marker:focus-visible {
+    outline: 3px solid rgba(100, 181, 246, 0.6);
+    outline-offset: 2px;
+}
+
+:root[data-theme="light"] .period-year-marker {
+    background: linear-gradient(135deg, #90caf9, #1976d2);
+    box-shadow: 0 0 16px rgba(25, 118, 210, 0.35), 0 0 0 2px rgba(255, 255, 255, 0.85);
+}
+
+:root[data-theme="light"] .period-year-marker--end {
+    background: linear-gradient(135deg, #64b5f6, #1565c0);
+}
+
+:root[data-theme="light"] .period-year-marker:hover,
+:root[data-theme="light"] .period-year-marker:focus-visible,
+:root[data-theme="light"] .period-year-marker.is-active {
+    box-shadow: 0 0 18px rgba(25, 118, 210, 0.45), 0 0 0 2px rgba(255, 255, 255, 0.8);
 }
 
 
@@ -526,6 +576,12 @@ h1 {
     z-index: 4;
 }
 
+.period.is-active {
+    opacity: 1;
+    transform: translateY(-50%) scale(1.05);
+    z-index: 5;
+}
+
 .period-card {
     position: absolute;
     left: 50%;
@@ -548,9 +604,11 @@ h1 {
 }
 
 .period:hover .period-card,
-.period:focus-visible .period-card {
+.period:focus-visible .period-card,
+.period.is-active .period-card {
     opacity: 1;
     transform: translate(-50%, 0) scale(1.02) scaleX(var(--timeline-zoom-inverse, 1));
+    pointer-events: auto;
 }
 
 .period-range {

--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -403,7 +403,7 @@ h1 {
 }
 
 :root[data-theme="light"] .timeline-tick-label {
-    box-shadow: 0 10px 18px rgba(92, 107, 192, 0.18);
+    box-shadow: 0 10px 20px rgba(92, 107, 192, 0.18);
 }
 
 .timeline-tick-label-start {
@@ -518,18 +518,18 @@ h1 {
 }
 
 :root[data-theme="light"] .period-year-marker {
-    background: linear-gradient(135deg, #90caf9, #1976d2);
-    box-shadow: 0 0 16px rgba(25, 118, 210, 0.35), 0 0 0 2px rgba(255, 255, 255, 0.85);
+    background: linear-gradient(135deg, #90caf9, #42a5f5);
+    box-shadow: 0 0 16px rgba(66, 165, 245, 0.35), 0 0 0 2px rgba(46, 64, 128, 0.25);
 }
 
 :root[data-theme="light"] .period-year-marker--end {
-    background: linear-gradient(135deg, #64b5f6, #1565c0);
+    background: linear-gradient(135deg, #64b5f6, #1e88e5);
 }
 
 :root[data-theme="light"] .period-year-marker:hover,
 :root[data-theme="light"] .period-year-marker:focus-visible,
 :root[data-theme="light"] .period-year-marker.is-active {
-    box-shadow: 0 0 18px rgba(25, 118, 210, 0.45), 0 0 0 2px rgba(255, 255, 255, 0.8);
+    box-shadow: 0 0 18px rgba(100, 181, 246, 0.45), 0 0 0 2px rgba(46, 64, 128, 0.22);
 }
 
 
@@ -562,7 +562,8 @@ h1 {
     min-width: 0;
 }
 
-.period:hover {
+.period:hover,
+.period.is-active {
     opacity: 1;
     transform: translateY(-50%) scale(1.04);
     z-index: 4;
@@ -574,12 +575,6 @@ h1 {
     opacity: 1;
     transform: translateY(-50%) scale(1.02);
     z-index: 4;
-}
-
-.period.is-active {
-    opacity: 1;
-    transform: translateY(-50%) scale(1.05);
-    z-index: 5;
 }
 
 .period-card {

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -199,7 +199,7 @@ document.addEventListener('DOMContentLoaded', () => {
         {
             maxZoom: Infinity,
             step: 1,
-            majorStep: 2
+            majorStep: 4
         }
     ];
 
@@ -408,8 +408,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 const marker = document.createElement('button');
                 marker.type = 'button';
                 marker.className = `period-year-marker period-year-marker--${variant}`;
-                marker.setAttribute('aria-label', `${variant === 'start' ? 'Inizio' : 'Fine'} di ${period.name}: ${year}`);
-                marker.title = `${variant === 'start' ? 'Inizio' : 'Fine'} · ${year}`;
+                const isStart = variant === 'start';
+                marker.setAttribute('aria-label', `${isStart ? 'Inizio' : 'Fine'} di ${period.name}: ${year}`);
+                marker.title = `${isStart ? 'Inizio' : 'Fine'} · ${year}`;
                 const position = ((year - minYear) / totalYears) * baseWidth;
                 marker.style.left = `${position}px`;
                 marker.dataset.year = String(year);
@@ -438,6 +439,26 @@ document.addEventListener('DOMContentLoaded', () => {
 
             el.addEventListener('pointerdown', (event) => {
                 event.stopPropagation();
+            });
+
+            el.addEventListener('click', (event) => {
+                event.stopPropagation();
+                if (activePeriodElement === el) {
+                    closeActivePeriodCard();
+                } else {
+                    openPeriodCard(el);
+                }
+            });
+
+            el.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    if (activePeriodElement === el) {
+                        closeActivePeriodCard();
+                    } else {
+                        openPeriodCard(el);
+                    }
+                }
             });
 
             el.addEventListener('focusout', (event) => {


### PR DESCRIPTION
## Summary
- restore timeline tick labels with denser spacing and updated styling to keep them legible
- replace textual period boundary badges with interactive blue markers that toggle the corresponding period card
- keep period cards open when activated while allowing dismissal via repeated clicks, outside taps, or Escape

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e7a7e652648326b07a66b19ca59f69