### PR TITLE
Restore timeline ticks and interactive period markers

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -20,8 +20,9 @@
     --tick-label-border: rgba(141, 158, 255, 0.3);
     --period-text-color: #ffffff;
     --period-shadow: rgba(0, 0, 0, 0.35);
-    --period-start-bg: rgba(8, 11, 36, 0.45);
-    --period-start-border: rgba(255, 255, 255, 0.32);
+    --period-boundary-bg: rgba(120, 172, 255, 0.95);
+    --period-boundary-border: rgba(46, 112, 255, 0.45);
+    --period-boundary-glow: rgba(120, 172, 255, 0.4);
     --event-marker-gradient: linear-gradient(135deg, #ffffff, #c5cae9);
     --event-marker-outline: rgba(255, 255, 255, 0.4);
     --event-marker-glow: rgba(255, 255, 255, 0.75);
@@ -71,8 +72,9 @@
     --tick-label-border: rgba(92, 107, 192, 0.35);
     --period-text-color: #1a1b2e;
     --period-shadow: rgba(122, 130, 180, 0.25);
-    --period-start-bg: rgba(92, 107, 192, 0.18);
-    --period-start-border: rgba(92, 107, 192, 0.28);
+    --period-boundary-bg: rgba(92, 148, 255, 0.95);
+    --period-boundary-border: rgba(46, 112, 255, 0.4);
+    --period-boundary-glow: rgba(92, 148, 255, 0.35);
     --event-marker-gradient: linear-gradient(135deg, #5c6bc0, #9fa8da);
     --event-marker-outline: rgba(92, 107, 192, 0.35);
     --event-marker-glow: rgba(92, 107, 192, 0.45);
@@ -383,6 +385,31 @@ h1 {
     background: var(--tick-major-color);
 }
 
+.timeline-tick-label {
+    position: absolute;
+    top: calc(50% + 40px);
+    transform: translateX(-50%) scaleX(var(--timeline-zoom-inverse, 1)) scaleY(var(--timeline-font-scale, 1));
+    transform-origin: top center;
+    padding: 4px 10px;
+    border-radius: 10px;
+    font-size: clamp(0.58rem, 0.56rem + 0.18vw, 0.82rem);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--tick-label-color);
+    background: var(--tick-label-bg);
+    border: 1px solid var(--tick-label-border);
+    box-shadow: 0 12px 24px rgba(5, 7, 19, 0.35);
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.16s ease;
+}
+
+.timeline-tick-label.visible {
+    opacity: 1;
+}
+
 .period {
     position: absolute;
     transform: translateY(-50%);
@@ -422,27 +449,49 @@ h1 {
     text-align: center;
 }
 
-.period-year-marker {
+
+.period-boundary {
     position: absolute;
     top: 50%;
     transform: translate(-50%, -50%) scaleX(var(--timeline-zoom-inverse, 1));
     transform-origin: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 999px;
+    border: 1px solid var(--period-boundary-border);
+    background: var(--period-boundary-bg);
+    box-shadow: 0 0 0 2px rgba(5, 24, 52, 0.3), 0 0 18px var(--period-boundary-glow);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 4px 10px;
-    border-radius: 999px;
-    font-size: clamp(0.6rem, 0.58rem + 0.18vw, 0.85rem);
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--period-text-color);
-    background: var(--period-start-bg);
-    box-shadow: inset 0 0 0 1px var(--period-start-border);
-    white-space: nowrap;
-    pointer-events: none;
-    z-index: 2;
-    line-height: 1.1;
+    cursor: pointer;
+    padding: 0;
+    color: transparent;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    z-index: 4;
+}
+
+.period-boundary::after {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.65);
+}
+
+.period-boundary:hover {
+    transform: translate(-50%, -50%) scale(1.1) scaleX(var(--timeline-zoom-inverse, 1));
+}
+
+.period-boundary[aria-pressed="true"] {
+    transform: translate(-50%, -50%) scale(1.2) scaleX(var(--timeline-zoom-inverse, 1));
+    box-shadow: 0 0 0 2px rgba(5, 24, 52, 0.36), 0 0 22px var(--period-boundary-glow);
+}
+
+.period-boundary:focus-visible {
+    outline: 3px solid var(--accent-primary);
+    outline-offset: 4px;
 }
 
 
@@ -510,10 +559,16 @@ h1 {
     text-align: left;
 }
 
-.period:hover .period-card,
-.period:focus-visible .period-card {
+.period--active {
+    opacity: 1;
+    transform: translateY(-50%) scale(1.05);
+    z-index: 5;
+}
+
+.period--active .period-card {
     opacity: 1;
     transform: translate(-50%, 0) scale(1.02) scaleX(var(--timeline-zoom-inverse, 1));
+    pointer-events: auto;
 }
 
 .period-range {


### PR DESCRIPTION
## Summary
- restore zoom-aware tick labels along the main timeline with updated styling for readability
- replace textual period boundary badges with interactive markers that toggle persistent period cards
- add dismissal behaviours for period cards via repeated clicks, outside taps, or Escape

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7b3ee7a3c8326b5bf332bfdefc767