### PR TITLE
Add SVG image for 1848 constitutional charters event

### DIFF
--- a/assets/js/timeline-data.js
+++ b/assets/js/timeline-data.js
@@ -181,7 +181,8 @@ window.TIMELINE_DATA = {
             date: "1848-02-10",
             title: "Carte costituzionali italiane del 1848",
             description: "Tra febbraio e marzo ottengono una carta il Regno delle Due Sicilie, la Toscana, Parma e lo Stato Pontificio. Nota: quasi tutte verranno sospese entro l'anno.",
-            level: 2
+            level: 2,
+            image: "https://www.1848-parl.ch/wGlobal/wGlobal/layout/images/logo_main_1848.svg"
         },
         {
             date: "1848-03-04",


### PR DESCRIPTION
## Summary
- add the official 1848 parliamentary SVG logo to the "Carte costituzionali italiane del 1848" timeline event

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7c7abe2348326a7f2f1aed9449e08