### PR TITLE
Replace period boundary dots with date labels

### DIFF
--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -456,41 +456,40 @@ h1 {
     top: 50%;
     transform: translate(-50%, -50%) scale(var(--timeline-zoom-inverse, 1));
     transform-origin: center;
-    min-width: 42px;
-    padding: 4px 10px;
-    border-radius: 999px;
-    border: 1px solid var(--tick-label-border);
-    background: var(--tick-label-bg);
+    min-width: 0;
+    padding: 4px 6px;
+    border-radius: 6px;
+    border: none;
+    background: transparent;
     color: var(--tick-label-color);
-    font-size: clamp(0.65rem, 0.6rem + 0.18vw, 0.85rem);
+    font-size: clamp(0.7rem, 0.62rem + 0.2vw, 0.9rem);
     font-weight: 600;
-    letter-spacing: 0.02em;
-    line-height: 1;
+    letter-spacing: 0.03em;
+    line-height: 1.1;
     text-align: center;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     white-space: nowrap;
-    box-shadow: 0 8px 16px rgba(8, 11, 36, 0.35);
+    box-shadow: none;
     cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+    transition: transform 0.2s ease, color 0.2s ease, background 0.2s ease;
     z-index: 4;
 }
 
 .period-boundary:hover {
-    transform: translate(-50%, -50%) scale(var(--timeline-zoom-inverse, 1)) scale(1.08);
-    box-shadow: 0 10px 22px rgba(8, 11, 36, 0.4);
+    color: var(--accent-primary);
+    transform: translate(-50%, -50%) scale(var(--timeline-zoom-inverse, 1)) scale(1.05);
 }
 
 .period-boundary[aria-pressed="true"] {
-    transform: translate(-50%, -50%) scale(var(--timeline-zoom-inverse, 1)) scale(1.12);
+    transform: translate(-50%, -50%) scale(var(--timeline-zoom-inverse, 1)) scale(1.08);
     background: var(--accent-primary);
     color: var(--year-badge-text);
-    box-shadow: 0 12px 24px rgba(8, 11, 36, 0.45);
 }
 
 .period-boundary:focus-visible {
-    outline: 3px solid var(--accent-primary);
+    outline: 2px solid var(--accent-primary);
     outline-offset: 4px;
 }
 


### PR DESCRIPTION
## Summary
- restyle the period boundary markers so they show numeric dates instead of circular dots
- adjust hover, active, and focus styles to match the new inline date labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e97a8dd6448326875acfadfe8b08ff