### PR TITLE
Fix timeline font scaling at extreme zoom levels

### DIFF
--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -701,14 +701,7 @@ document.addEventListener('DOMContentLoaded', () => {
         zoomLevelEl.textContent = `${Math.round(state.zoom * 100)}%`;
     };
 
-    const computeTextScale = (zoom) => {
-        if (zoom >= 1) {
-            const compensated = Math.pow(zoom, -0.35);
-            return clamp(compensated, 0.85, 1);
-        }
-        const compensated = 1 / zoom;
-        return clamp(compensated, 1, 5);
-    };
+    const computeTextScale = () => 1;
 
     const updateDetailLevels = () => {
         inner.classList.remove('zoom-low', 'zoom-medium', 'zoom-high');


### PR DESCRIPTION
## Summary
- keep the timeline font scale constant so text remains legible even at very low zoom values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e97fc2dc808326bce0c512f61cd69f