### PR TITLE
Update icon for democratic transition period

### DIFF
--- a/assets/js/timeline-data.js
+++ b/assets/js/timeline-data.js
@@ -144,7 +144,7 @@ window.TIMELINE_DATA = {
             end: 1946,
             color: "rgba(186,104,200,0.45)",
             lane: 0,
-            icon: "https://upload.wikimedia.org/wikipedia/commons/5/57/DC_Party_Logo_%281943-1968%29.svg",
+            icon: "https://upload.wikimedia.org/wikipedia/commons/8/86/DC_Party_Logo_%281968-1992%29.svg",
             iconAlt: "Logo scudocrociato della Democrazia Cristiana",
             description: "Dal crollo del regime alla cobelligeranza, i Comitati di Liberazione e i governi di unità traghettano il Paese verso la scelta repubblicana."
         },


### PR DESCRIPTION
## Summary
- update the "Transizione alla democrazia" period to use the Democrazia Cristiana 1968-1992 scudocrociato logo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e98cd6bcb48326abd23873560aa9d5